### PR TITLE
Fix fill canvas (and release 0.4.0)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -433,7 +433,7 @@
 
     this.fillCanvas = function (color) {
       return this
-        .clearCanvas()
+        .resetTransform()
         .fillRect(0, 0, this.getWidth(), this.getHeight(), color);
     }.bind(this);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canvasimo",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A simple, fluent interface that extends, and standardizes the HTML5 Canvas API",
   "main": "lib/index.js",
   "directories": {


### PR DESCRIPTION
Do not clear canvas before filling it. This allows filling the canvas with alpha values.