### PR TITLE
Multiline text

### DIFF
--- a/docs/src/css/styles.css
+++ b/docs/src/css/styles.css
@@ -129,7 +129,7 @@ a:hover {
 .demo-container {
   position: relative;
   width: 100%;
-  height: 200px;
+  height: 300px;
 }
 
 canvas {

--- a/docs/src/css/styles.css
+++ b/docs/src/css/styles.css
@@ -129,7 +129,7 @@ a:hover {
 .demo-container {
   position: relative;
   width: 100%;
-  height: 300px;
+  height: 200px;
 }
 
 canvas {

--- a/docs/src/css/styles.css
+++ b/docs/src/css/styles.css
@@ -44,7 +44,7 @@ hr {
 code,
 pre {
   background-color: #f5f5f5;
-  color: #777;
+  color: #555;
   border-radius: 2px;
   border: 1px solid #f0f0f0;
   font-family: monospace;

--- a/docs/src/ts/components/document.tsx
+++ b/docs/src/ts/components/document.tsx
@@ -1,5 +1,5 @@
-const fs = require('fs');
-const path = require('path');
+import * as fs from 'fs';
+import * as path from 'path';
 import * as React from 'react';
 import { Component } from 'react';
 import { Docs } from '../types';

--- a/docs/src/ts/components/document.tsx
+++ b/docs/src/ts/components/document.tsx
@@ -13,10 +13,19 @@ const MATCHES_CANVASIMO_PATH = /'.+'/;
 
 // tslint:disable-next-line:no-var-requires
 const docs: Docs = require('../../../build/json/docs.json');
-const example = fs.readFileSync(path.join(__dirname, '../example.ts'), 'utf8')
-  .replace(MATCHES_CANVASIMO_IMPORT, (subString: string) => {
-    return subString.replace(MATCHES_CANVASIMO_PATH, '\'canvasimo\'');
-  });
+
+const getExampleCode = (code: string) => {
+  return code.replace(MATCHES_CANVASIMO_IMPORT, (subString: string) => {
+      return subString.replace(MATCHES_CANVASIMO_PATH, '\'canvasimo\'');
+    });
+};
+
+const exampleBasicShapes = getExampleCode(
+  fs.readFileSync(path.join(__dirname, `../examples/basic-shapes.ts`), 'utf8')
+);
+const exampleMultilineText = getExampleCode(
+  fs.readFileSync(path.join(__dirname, `../examples/multiline-text.ts`), 'utf8')
+);
 
 const TITLE = 'Canvasimo | The fluent HTML5 canvas drawing library';
 
@@ -208,10 +217,12 @@ export default class Document extends Component<Props, {}> {
                     stroke('green')</code>, <code>fillCanvas('blue')</code>.
                 </p>
 
-                <LinkHeader type="h2" header="Example" />
+                <LinkHeader type="h2" header="Examples" />
+
+                <LinkHeader type="h3" header="Basic shapes" />
 
                 <div className="demo-container">
-                  <canvas id="example-1" width="400" height="200">
+                  <canvas id="example-basic-shapes" width="400" height="200">
                     Looks like this browser doesn't support the canvas element, or you have javascript disabled.
                   </canvas>
                 </div>
@@ -219,7 +230,20 @@ export default class Document extends Component<Props, {}> {
                   You must have javascript enabled for this example.
                 </noscript>
 
-                <pre>{example}</pre>
+                <pre>{exampleBasicShapes}</pre>
+
+                <LinkHeader type="h3" header="Multiline text" />
+
+                <div className="demo-container">
+                  <canvas id="example-multiline-text" width="400" height="200">
+                    Looks like this browser doesn't support the canvas element, or you have javascript disabled.
+                  </canvas>
+                </div>
+                <noscript>
+                  You must have javascript enabled for this example.
+                </noscript>
+
+                <pre>{exampleMultilineText}</pre>
 
                 <LinkHeader type="h1" header="Documentation" className="main-header" />
 

--- a/docs/src/ts/components/document.tsx
+++ b/docs/src/ts/components/document.tsx
@@ -21,10 +21,10 @@ const getExampleCode = (code: string) => {
 };
 
 const exampleBasicShapes = getExampleCode(
-  fs.readFileSync(path.join(__dirname, `../examples/basic-shapes.ts`), 'utf8')
+  fs.readFileSync(path.join(__dirname, '../examples/basic-shapes.ts'), 'utf8')
 );
 const exampleMultilineText = getExampleCode(
-  fs.readFileSync(path.join(__dirname, `../examples/multiline-text.ts`), 'utf8')
+  fs.readFileSync(path.join(__dirname, '../examples/multiline-text.ts'), 'utf8')
 );
 
 const TITLE = 'Canvasimo | The fluent HTML5 canvas drawing library';

--- a/docs/src/ts/example.ts
+++ b/docs/src/ts/example.ts
@@ -6,6 +6,7 @@ if (!element) {
   throw new Error('Could not find canvas element for example');
 }
 
+const FONT_SIZE = 14;
 const canvas = new Canvasimo(element as HTMLCanvasElement);
 const rect = canvas.getBoundingClientRect();
 
@@ -23,6 +24,23 @@ const draw = () => {
     .clearCanvas()
     .setSize(width, height)
     .fillCanvas('#EEEEEE')
+    .setTextBaseline('top')
+    .setFontFamily('arial')
+    .setFontSize(FONT_SIZE)
+    .fillText('Regular text', 10, 10, null, 'black')
+    .fillTextWrap(
+      'Text with newline after this...\n...so this is on a newline',
+      10,
+      10 + FONT_SIZE * 2
+    )
+    .fillTextWrap(
+      'Text that automatically wraps and, in this case, is hyphenated',
+      10,
+      10 + FONT_SIZE * 5,
+      100,
+      true,
+      true
+    )
     .save()
     .translate(width / 2, height / 2)
     .rotate(canvas.getRadiansFromDegrees(-90))

--- a/docs/src/ts/example.ts
+++ b/docs/src/ts/example.ts
@@ -34,12 +34,11 @@ const draw = () => {
       10 + FONT_SIZE * 2
     )
     .fillTextMultiline(
-      'Text that automatically wraps and, in this case, is hyphenated',
+      'Text that automatically wraps and breaks words if necessary',
       10,
       10 + FONT_SIZE * 5,
       100,
-      true,
-      true
+      'break-word'
     )
     .save()
     .translate(width / 2, height / 2)

--- a/docs/src/ts/example.ts
+++ b/docs/src/ts/example.ts
@@ -41,6 +41,13 @@ const draw = () => {
       100,
       'break-word'
     )
+    .fillTextMultiline(
+      'Text that automatically wraps and always breaks words',
+      10,
+      10 + FONT_SIZE * 10,
+      100,
+      'break-all'
+    )
     .save()
     .translate(width / 2, height / 2)
     .rotate(canvas.getRadiansFromDegrees(-90))

--- a/docs/src/ts/example.ts
+++ b/docs/src/ts/example.ts
@@ -27,6 +27,7 @@ const draw = () => {
     .setTextBaseline('top')
     .setFontFamily('arial')
     .setFontSize(FONT_SIZE)
+    .strokeLine(10 + 100, 0, 10 + 100, height, 'black')
     .fillText('Regular text', 10, 10, null, 'black')
     .fillTextMultiline(
       'Text with newline after this...\n...so this is on a newline',

--- a/docs/src/ts/example.ts
+++ b/docs/src/ts/example.ts
@@ -6,6 +6,7 @@ if (!element) {
   throw new Error('Could not find canvas element for example');
 }
 
+const MULTILINE_TEXT_WIDTH = 80;
 const FONT_SIZE = 14;
 const canvas = new Canvasimo(element as HTMLCanvasElement);
 const rect = canvas.getBoundingClientRect();
@@ -27,25 +28,32 @@ const draw = () => {
     .setTextBaseline('top')
     .setFontFamily('arial')
     .setFontSize(FONT_SIZE)
-    .strokeLine(10 + 100, 0, 10 + 100, height, 'black')
-    .fillText('Regular text', 10, 10, null, 'black')
+    .strokeLine(10 + MULTILINE_TEXT_WIDTH, 0, 10 + MULTILINE_TEXT_WIDTH, height, 'black')
+    .fillText('Regular text that does not have newlines or automatic wrapping', 10, 10, null, 'black')
     .fillTextMultiline(
       'Text with newline after this...\n...so this is on a newline',
       10,
       10 + FONT_SIZE * 2
     )
     .fillTextMultiline(
-      'Text that automatically wraps and breaks words if necessary',
+      'Text that automatically wraps and but never breaks words',
       10,
       10 + FONT_SIZE * 5,
-      100,
+      MULTILINE_TEXT_WIDTH,
+      'normal'
+    )
+    .fillTextMultiline(
+      'Text that automatically wraps and breaks words if necessary',
+      10,
+      10 + FONT_SIZE * 10,
+      MULTILINE_TEXT_WIDTH,
       'break-word'
     )
     .fillTextMultiline(
       'Text that automatically wraps and always breaks words',
       10,
-      10 + FONT_SIZE * 10,
-      100,
+      10 + FONT_SIZE * 15,
+      MULTILINE_TEXT_WIDTH,
       'break-all'
     )
     .save()

--- a/docs/src/ts/example.ts
+++ b/docs/src/ts/example.ts
@@ -28,12 +28,12 @@ const draw = () => {
     .setFontFamily('arial')
     .setFontSize(FONT_SIZE)
     .fillText('Regular text', 10, 10, null, 'black')
-    .fillTextWrap(
+    .fillTextMultiline(
       'Text with newline after this...\n...so this is on a newline',
       10,
       10 + FONT_SIZE * 2
     )
-    .fillTextWrap(
+    .fillTextMultiline(
       'Text that automatically wraps and, in this case, is hyphenated',
       10,
       10 + FONT_SIZE * 5,

--- a/docs/src/ts/example.ts
+++ b/docs/src/ts/example.ts
@@ -6,7 +6,7 @@ if (!element) {
   throw new Error('Could not find canvas element for example');
 }
 
-const MULTILINE_TEXT_WIDTH = 80;
+const MULTILINE_TEXT_WIDTH = 70;
 const FONT_SIZE = 14;
 const canvas = new Canvasimo(element as HTMLCanvasElement);
 const rect = canvas.getBoundingClientRect();
@@ -28,7 +28,9 @@ const draw = () => {
     .setTextBaseline('top')
     .setFontFamily('arial')
     .setFontSize(FONT_SIZE)
-    .strokeLine(10 + MULTILINE_TEXT_WIDTH, 0, 10 + MULTILINE_TEXT_WIDTH, height, 'black')
+    .strokeLine(10 + MULTILINE_TEXT_WIDTH, 0, 10 + MULTILINE_TEXT_WIDTH, height, '#AAAAAA')
+    .strokeLine(10 + MULTILINE_TEXT_WIDTH * 2, 0, 10 + MULTILINE_TEXT_WIDTH * 2, height, '#AAAAAA')
+    .strokeLine(10 + MULTILINE_TEXT_WIDTH * 3, 0, 10 + MULTILINE_TEXT_WIDTH * 3, height, '#AAAAAA')
     .fillText('Regular text that does not have newlines or automatic wrapping', 10, 10, null, 'black')
     .fillTextMultiline(
       'Text with newline after this...\n...so this is on a newline',
@@ -36,25 +38,25 @@ const draw = () => {
       10 + FONT_SIZE * 2
     )
     .fillTextMultiline(
-      'Text that automatically wraps and but never breaks words',
-      10,
-      10 + FONT_SIZE * 5,
-      MULTILINE_TEXT_WIDTH,
-      'normal'
-    )
-    .fillTextMultiline(
       'Text that automatically wraps and breaks words if necessary',
       10,
-      10 + FONT_SIZE * 10,
+      10 + FONT_SIZE * 5,
       MULTILINE_TEXT_WIDTH,
       'break-word'
     )
     .fillTextMultiline(
       'Text that automatically wraps and always breaks words',
-      10,
-      10 + FONT_SIZE * 15,
+      10 + MULTILINE_TEXT_WIDTH,
+      10 + FONT_SIZE * 5,
       MULTILINE_TEXT_WIDTH,
       'break-all'
+    )
+    .fillTextMultiline(
+      'Text that automatically wraps but never breaks words',
+      10 + MULTILINE_TEXT_WIDTH * 2,
+      10 + FONT_SIZE * 5,
+      MULTILINE_TEXT_WIDTH,
+      'normal'
     )
     .save()
     .translate(width / 2, height / 2)

--- a/docs/src/ts/examples/basic-shapes.ts
+++ b/docs/src/ts/examples/basic-shapes.ts
@@ -25,39 +25,6 @@ const draw = () => {
     .clearCanvas()
     .setSize(width, height)
     .fillCanvas('#EEEEEE')
-    .setTextBaseline('top')
-    .setFontFamily('arial')
-    .setFontSize(FONT_SIZE)
-    .strokeLine(10 + MULTILINE_TEXT_WIDTH, 0, 10 + MULTILINE_TEXT_WIDTH, height, '#AAAAAA')
-    .strokeLine(10 + MULTILINE_TEXT_WIDTH * 2, 0, 10 + MULTILINE_TEXT_WIDTH * 2, height, '#AAAAAA')
-    .strokeLine(10 + MULTILINE_TEXT_WIDTH * 3, 0, 10 + MULTILINE_TEXT_WIDTH * 3, height, '#AAAAAA')
-    .fillText('Regular text that does not have newlines or automatic wrapping', 10, 10, null, 'black')
-    .fillTextMultiline(
-      'Text with newline after this...\n...so this is on a newline',
-      10,
-      10 + FONT_SIZE * 2
-    )
-    .fillTextMultiline(
-      'Text that automatically wraps and breaks words if necessary',
-      10,
-      10 + FONT_SIZE * 5,
-      MULTILINE_TEXT_WIDTH,
-      'break-word'
-    )
-    .fillTextMultiline(
-      'Text that automatically wraps and always breaks words',
-      10 + MULTILINE_TEXT_WIDTH,
-      10 + FONT_SIZE * 5,
-      MULTILINE_TEXT_WIDTH,
-      'break-all'
-    )
-    .fillTextMultiline(
-      'Text that automatically wraps but never breaks words',
-      10 + MULTILINE_TEXT_WIDTH * 2,
-      10 + FONT_SIZE * 5,
-      MULTILINE_TEXT_WIDTH,
-      'normal'
-    )
     .save()
     .translate(width / 2, height / 2)
     .rotate(canvas.getRadiansFromDegrees(-90))

--- a/docs/src/ts/examples/basic-shapes.ts
+++ b/docs/src/ts/examples/basic-shapes.ts
@@ -1,9 +1,9 @@
-import Canvasimo from '../../../src';
+import Canvasimo from '../../../../src';
 
-const element = document.getElementById('example-1');
+const element = document.getElementById('example-basic-shapes');
 
 if (!element) {
-  throw new Error('Could not find canvas element for example');
+  throw new Error('Could not find canvas element for basic shapes example');
 }
 
 const MULTILINE_TEXT_WIDTH = 70;

--- a/docs/src/ts/examples/basic-shapes.ts
+++ b/docs/src/ts/examples/basic-shapes.ts
@@ -6,8 +6,6 @@ if (!element) {
   throw new Error('Could not find canvas element for basic shapes example');
 }
 
-const MULTILINE_TEXT_WIDTH = 70;
-const FONT_SIZE = 14;
 const canvas = new Canvasimo(element as HTMLCanvasElement);
 const rect = canvas.getBoundingClientRect();
 

--- a/docs/src/ts/examples/multiline-text.ts
+++ b/docs/src/ts/examples/multiline-text.ts
@@ -57,7 +57,7 @@ const draw = () => {
     .setTextAlign('center')
     .fillTextMultiline(
       'break-word\nText that automatically wraps and breaks words if necessary',
-      MARGIN,
+      MARGIN + multilineTextWidth / 2,
       MARGIN + FONT_SIZE * 5,
       multilineTextWidth,
       'break-word'
@@ -67,7 +67,7 @@ const draw = () => {
     .setTextAlign('right')
     .fillTextMultiline(
       'break-all\nText that automatically wraps and always breaks words',
-      MARGIN,
+      MARGIN + multilineTextWidth,
       MARGIN + FONT_SIZE * 5,
       multilineTextWidth,
       'break-all'

--- a/docs/src/ts/examples/multiline-text.ts
+++ b/docs/src/ts/examples/multiline-text.ts
@@ -45,7 +45,7 @@ const draw = () => {
     .translate(multilineTextOffset, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA')
     .fillTextMultiline(
-      'Text that automatically wraps but never breaks words',
+      'non-breaking\nText that automatically wraps but never breaks words',
       SPACE,
       SPACE + FONT_SIZE * 5,
       multilineTextWidth,
@@ -54,7 +54,7 @@ const draw = () => {
     .translate(SPACE * 2 + multilineTextWidth, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA')
     .fillTextMultiline(
-      'Text that automatically wraps and breaks words if necessary',
+      'break-word\nText that automatically wraps and breaks words if necessary',
       SPACE,
       SPACE + FONT_SIZE * 5,
       multilineTextWidth,
@@ -63,7 +63,7 @@ const draw = () => {
     .translate(SPACE * 2 + multilineTextWidth, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA')
     .fillTextMultiline(
-      'Text that automatically wraps and always breaks words',
+      'break-all\nText that automatically wraps and always breaks words',
       SPACE,
       SPACE + FONT_SIZE * 5,
       multilineTextWidth,

--- a/docs/src/ts/examples/multiline-text.ts
+++ b/docs/src/ts/examples/multiline-text.ts
@@ -1,0 +1,78 @@
+import Canvasimo from '../../../../src';
+
+const element = document.getElementById('example-multiline-text');
+
+if (!element) {
+  throw new Error('Could not find canvas element for multiline text example');
+}
+
+const SPACE = 10;
+const FONT_SIZE = 14;
+const canvas = new Canvasimo(element as HTMLCanvasElement);
+const rect = canvas.getBoundingClientRect();
+
+canvas
+  .setDensity(2)
+  .setSize(rect.width, rect.height);
+
+const draw = () => {
+  const { width } = canvas.getBoundingClientRect();
+  const height = canvas.getHeight();
+
+  const multilineTextArea = Math.min(width / 3 * 2, 400);
+  const multilineTextOffset = (width - multilineTextArea) / 2;
+  const multilineTextWidth = (multilineTextArea - SPACE * 6) / 3;
+
+  canvas
+    .clearCanvas()
+    .setSize(width, height)
+    .fillCanvas('#FFFFFF')
+    .setTextBaseline('top')
+    .setFontFamily('arial')
+    .setFontSize(FONT_SIZE)
+    .fillText(
+      'Regular text that does not have newlines or automatic wrapping',
+      SPACE,
+      SPACE,
+      null,
+      'black'
+    )
+    .fillTextMultiline(
+      'Text with newline after this...\n...so this is on a newline',
+      SPACE,
+      FONT_SIZE * 2
+    )
+    .translate(multilineTextOffset, 0)
+    .strokeLine(0, 0, 0, height, '#AAAAAA')
+    .fillTextMultiline(
+      'Text that automatically wraps and breaks words if necessary',
+      SPACE,
+      SPACE + FONT_SIZE * 5,
+      multilineTextWidth,
+      'break-word'
+    )
+    .translate(SPACE * 2 + multilineTextWidth, 0)
+    .strokeLine(0, 0, 0, height, '#AAAAAA')
+    .fillTextMultiline(
+      'Text that automatically wraps and always breaks words',
+      SPACE,
+      SPACE + FONT_SIZE * 5,
+      multilineTextWidth,
+      'break-all'
+    )
+    .translate(SPACE * 2 + multilineTextWidth, 0)
+    .strokeLine(0, 0, 0, height, '#AAAAAA')
+    .fillTextMultiline(
+      'Text that automatically wraps but never breaks words',
+      SPACE,
+      SPACE + FONT_SIZE * 5,
+      multilineTextWidth,
+      'normal'
+    )
+    .translate(SPACE * 2 + multilineTextWidth, 0)
+    .strokeLine(0, 0, 0, height, '#AAAAAA');
+};
+
+draw();
+
+window.addEventListener('resize', draw);

--- a/docs/src/ts/examples/multiline-text.ts
+++ b/docs/src/ts/examples/multiline-text.ts
@@ -42,6 +42,19 @@ const draw = () => {
       MARGIN,
       FONT_SIZE * 2
     )
+    .setTextAlign('center')
+    .setFontSize(FONT_SIZE - 2)
+    .fillTextMultiline(
+      'Try resizing the window! :D',
+      width / 2,
+      FONT_SIZE * 4,
+      width - MARGIN * 2,
+      undefined,
+      undefined,
+      '#555555'
+    )
+    .setFontSize(FONT_SIZE)
+    .setFill('black')
     .translate(multilineTextOffset, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA')
     .setTextAlign('left')

--- a/docs/src/ts/examples/multiline-text.ts
+++ b/docs/src/ts/examples/multiline-text.ts
@@ -45,6 +45,15 @@ const draw = () => {
     .translate(multilineTextOffset, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA')
     .fillTextMultiline(
+      'Text that automatically wraps but never breaks words',
+      SPACE,
+      SPACE + FONT_SIZE * 5,
+      multilineTextWidth,
+      'normal'
+    )
+    .translate(SPACE * 2 + multilineTextWidth, 0)
+    .strokeLine(0, 0, 0, height, '#AAAAAA')
+    .fillTextMultiline(
       'Text that automatically wraps and breaks words if necessary',
       SPACE,
       SPACE + FONT_SIZE * 5,
@@ -59,15 +68,6 @@ const draw = () => {
       SPACE + FONT_SIZE * 5,
       multilineTextWidth,
       'break-all'
-    )
-    .translate(SPACE * 2 + multilineTextWidth, 0)
-    .strokeLine(0, 0, 0, height, '#AAAAAA')
-    .fillTextMultiline(
-      'Text that automatically wraps but never breaks words',
-      SPACE,
-      SPACE + FONT_SIZE * 5,
-      multilineTextWidth,
-      'normal'
     )
     .translate(SPACE * 2 + multilineTextWidth, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA');

--- a/docs/src/ts/examples/multiline-text.ts
+++ b/docs/src/ts/examples/multiline-text.ts
@@ -44,6 +44,7 @@ const draw = () => {
     )
     .translate(multilineTextOffset, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA')
+    .setTextAlign('left')
     .fillTextMultiline(
       'normal\nText that automatically wraps but never breaks words',
       MARGIN,
@@ -53,6 +54,7 @@ const draw = () => {
     )
     .translate(MARGIN * 2 + multilineTextWidth, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA')
+    .setTextAlign('center')
     .fillTextMultiline(
       'break-word\nText that automatically wraps and breaks words if necessary',
       MARGIN,
@@ -62,6 +64,7 @@ const draw = () => {
     )
     .translate(MARGIN * 2 + multilineTextWidth, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA')
+    .setTextAlign('right')
     .fillTextMultiline(
       'break-all\nText that automatically wraps and always breaks words',
       MARGIN,

--- a/docs/src/ts/examples/multiline-text.ts
+++ b/docs/src/ts/examples/multiline-text.ts
@@ -6,7 +6,7 @@ if (!element) {
   throw new Error('Could not find canvas element for multiline text example');
 }
 
-const SPACE = 10;
+const MARGIN = 10;
 const FONT_SIZE = 14;
 const canvas = new Canvasimo(element as HTMLCanvasElement);
 const rect = canvas.getBoundingClientRect();
@@ -21,7 +21,7 @@ const draw = () => {
 
   const multilineTextArea = Math.min(width / 3 * 2, 400);
   const multilineTextOffset = (width - multilineTextArea) / 2;
-  const multilineTextWidth = (multilineTextArea - SPACE * 6) / 3;
+  const multilineTextWidth = (multilineTextArea - MARGIN * 6) / 3;
 
   canvas
     .clearCanvas()
@@ -32,44 +32,44 @@ const draw = () => {
     .setFontSize(FONT_SIZE)
     .fillText(
       'Regular text that does not have newlines or automatic wrapping',
-      SPACE,
-      SPACE,
+      MARGIN,
+      MARGIN,
       null,
       'black'
     )
     .fillTextMultiline(
       'Text with newline after this...\n...so this is on a newline',
-      SPACE,
+      MARGIN,
       FONT_SIZE * 2
     )
     .translate(multilineTextOffset, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA')
     .fillTextMultiline(
       'normal\nText that automatically wraps but never breaks words',
-      SPACE,
-      SPACE + FONT_SIZE * 5,
+      MARGIN,
+      MARGIN + FONT_SIZE * 5,
       multilineTextWidth,
       'normal'
     )
-    .translate(SPACE * 2 + multilineTextWidth, 0)
+    .translate(MARGIN * 2 + multilineTextWidth, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA')
     .fillTextMultiline(
       'break-word\nText that automatically wraps and breaks words if necessary',
-      SPACE,
-      SPACE + FONT_SIZE * 5,
+      MARGIN,
+      MARGIN + FONT_SIZE * 5,
       multilineTextWidth,
       'break-word'
     )
-    .translate(SPACE * 2 + multilineTextWidth, 0)
+    .translate(MARGIN * 2 + multilineTextWidth, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA')
     .fillTextMultiline(
       'break-all\nText that automatically wraps and always breaks words',
-      SPACE,
-      SPACE + FONT_SIZE * 5,
+      MARGIN,
+      MARGIN + FONT_SIZE * 5,
       multilineTextWidth,
       'break-all'
     )
-    .translate(SPACE * 2 + multilineTextWidth, 0)
+    .translate(MARGIN * 2 + multilineTextWidth, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA');
 };
 

--- a/docs/src/ts/examples/multiline-text.ts
+++ b/docs/src/ts/examples/multiline-text.ts
@@ -45,7 +45,7 @@ const draw = () => {
     .translate(multilineTextOffset, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA')
     .fillTextMultiline(
-      'non-breaking\nText that automatically wraps but never breaks words',
+      'normal\nText that automatically wraps but never breaks words',
       SPACE,
       SPACE + FONT_SIZE * 5,
       multilineTextWidth,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "typescript": "2.3.4"
   },
   "jest": {
-    "mapCoverage": true,
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}"
     ],

--- a/scripts/generate-docs.tsx
+++ b/scripts/generate-docs.tsx
@@ -13,20 +13,25 @@ import getDocJson from './get-doc-json';
 const UTF8 = 'utf8';
 
 const CWD = process.cwd();
+const DOCS_DIR = path.join(CWD, 'docs/src/ts');
+const EXAMPLES_DIR = path.join(DOCS_DIR, 'examples');
 const SHOULD_WATCH = process.argv[2] === 'watch';
 const MATCHES_EXTENSION = /\.(js|jsx|ts|tsx|json)$/;
 
 const packageJSON = JSON.parse(fs.readFileSync(path.join(CWD, 'package.json'), UTF8));
 
+const examples = fs.readdirSync(EXAMPLES_DIR, UTF8).map((example) => {
+  return path.join(EXAMPLES_DIR, example);
+});
+
 const b = browserify(
   {
     entries: [
-      path.join(CWD, 'docs/src/ts/polyfills.ts'),
-      path.join(CWD, 'docs/src/ts/sidebar.tsx'),
-      path.join(CWD, 'docs/src/ts/demo.ts'),
-      path.join(CWD, 'docs/src/ts/example.ts'),
-      path.join(CWD, 'docs/src/ts/tracking.ts'),
-    ],
+      path.join(DOCS_DIR, 'polyfills.ts'),
+      path.join(DOCS_DIR, 'sidebar.tsx'),
+      path.join(DOCS_DIR, 'demo.ts'),
+      path.join(DOCS_DIR, 'tracking.ts'),
+    ].concat(examples),
     paths: ['node_modules'],
     debug: true,
     cache: {},
@@ -105,7 +110,7 @@ const copyFilesToBuildDirectory = (verbose: boolean) => {
 };
 
 const createDocumentation = () => {
-  const Document = require(path.join(CWD, 'docs/src/ts/components/document')).default;
+  const Document = require(path.join(DOCS_DIR, 'components/document')).default;
 
   fs.writeFile(
     path.join(CWD, 'docs/index.html'),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,4 +42,4 @@ export const MATCHES_SPECIAL_FONT = /^(caption|icon|menu|message-box|small-capti
 export const MATCHES_WHITESPACE = /\s+/g;
 export const MATCHES_ALL_WHITESPACE = /^\s*$/;
 export const MATCHES_FONT_SIZE = /(^|\s+)(\d*\.?\d+)([a-z]+|%)(\/\d*\.?\d+(?:[a-z]+|%)?)?\s/i;
-export const MATCHES_WORD_BREAKS = /\b/g;
+export const MATCHES_WORD_BREAKS = /(?!-)\b/g;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,5 +40,6 @@ export const MATCHES_FONT_VARIANT = /^(small-caps)$/i;
 export const MATCHES_FONT_WEIGHT = /^(bold|bolder|lighter|\d00)$/i;
 export const MATCHES_SPECIAL_FONT = /^(caption|icon|menu|message-box|small-caption|status-bar)$/i;
 export const MATCHES_WHITESPACE = /\s+/g;
+export const MATCHES_ALL_WHITESPACE = /^\s*$/;
 export const MATCHES_FONT_SIZE = /(^|\s+)(\d*\.?\d+)([a-z]+|%)(\/\d*\.?\d+(?:[a-z]+|%)?)?\s/i;
-export const MATCHES_WORD_OR_BREAK = /(?:([^\s-]+)|([\s-]+))/g;
+export const MATCHES_WORD_BREAKS = /\b/g;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -42,4 +42,4 @@ export const MATCHES_SPECIAL_FONT = /^(caption|icon|menu|message-box|small-capti
 export const MATCHES_WHITESPACE = /\s+/g;
 export const MATCHES_ALL_WHITESPACE = /^\s*$/;
 export const MATCHES_FONT_SIZE = /(^|\s+)(\d*\.?\d+)([a-z]+|%)(\/\d*\.?\d+(?:[a-z]+|%)?)?\s/i;
-export const MATCHES_WORD_BREAKS = /(?!-)\b/g;
+export const MATCHES_WORD_BREAKS = /(?![^\w\s])\b/g;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -41,3 +41,4 @@ export const MATCHES_FONT_WEIGHT = /^(bold|bolder|lighter|\d00)$/i;
 export const MATCHES_SPECIAL_FONT = /^(caption|icon|menu|message-box|small-caption|status-bar)$/i;
 export const MATCHES_WHITESPACE = /\s+/g;
 export const MATCHES_FONT_SIZE = /(^|\s+)(\d*\.?\d+)([a-z]+|%)(\/\d*\.?\d+(?:[a-z]+|%)?)?\s/i;
+export const MATCHES_WORD_OR_BREAK = /(?:([^\s-]+)|([\s-]+))/g;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -40,4 +40,4 @@ export const MATCHES_FONT_VARIANT = /^(small-caps)$/i;
 export const MATCHES_FONT_WEIGHT = /^(bold|bolder|lighter|\d00)$/i;
 export const MATCHES_SPECIAL_FONT = /^(caption|icon|menu|message-box|small-caption|status-bar)$/i;
 export const MATCHES_WHITESPACE = /\s+/g;
-export const MATCHES_FONT_SIZE = /(^|\s+)(\d*\.?\d+)([a-z]+|%)\s/i;
+export const MATCHES_FONT_SIZE = /(^|\s+)(\d*\.?\d+)([a-z]+|%)(\/\d*\.?\d+(?:[a-z]+|%)?)?\s/i;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import {
   GlobalCompositeOperation,
   LineCap,
   LineJoin,
+  MaxWidth,
   Points,
   Repeat,
   Segments,
@@ -819,7 +820,7 @@ export class Canvasimo {
   /**
    * Draw a text with a stroke.
    */
-  public strokeText = (text: string, x: number, y: number, maxWidth?: number, color?: string): Canvasimo => {
+  public strokeText = (text: string, x: number, y: number, maxWidth?: MaxWidth, color?: string): Canvasimo => {
     if (typeof color !== 'undefined') {
       this.setStroke(color);
     }
@@ -833,7 +834,7 @@ export class Canvasimo {
   /**
    * Draw a text with a fill.
    */
-  public fillText = (text: string, x: number, y: number, maxWidth?: number, color?: string): Canvasimo => {
+  public fillText = (text: string, x: number, y: number, maxWidth?: MaxWidth, color?: string): Canvasimo => {
     if (typeof color !== 'undefined') {
       this.setFill(color);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -855,7 +855,7 @@ export class Canvasimo {
    * If the hyphenated parameter is true, breakWord will be ignored.
    * The lineHeight parameter is a multiplier for the font size, and defaults to 1.5.
    */
-  public strokeTextWrap = (
+  public strokeTextMultiline = (
     text: string,
     x: number,
     y: number,
@@ -885,7 +885,7 @@ export class Canvasimo {
    * If the hyphenated parameter is true, breakWord will be ignored.
    * The lineHeight parameter is a multiplier for the font size, and defaults to 1.5.
    */
-  public fillTextWrap = (
+  public fillTextMultiline = (
     text: string,
     x: number,
     y: number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,6 @@ export class Canvasimo {
 
     this.density = density;
 
-    // FIXME: Test that these are correctly adjusted
     if (prevDensity !== density) {
       this.setSize(this.element.width, this.element.height);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -946,6 +946,7 @@ export class Canvasimo {
   }
   /**
    * Get the font that is being used.
+   * This returns the exact CanvasRenderingContext2D.font string.
    */
   public getFont = (): string => {
     return formatFont(this.ctx.font, this.density);
@@ -986,6 +987,7 @@ export class Canvasimo {
   }
   /**
    * Get the font size that is being used.
+   * Returns null if using a special font e.g. caption, icon, menu.
    */
   public getFontSize = (): number | null => {
     const parts = getFontParts(this.ctx.font, this.density);
@@ -1008,6 +1010,7 @@ export class Canvasimo {
   }
   /**
    * Get the font style that is being used.
+   * Returns null if using a special font e.g. caption, icon, menu.
    */
   public getFontStyle = (): string | null => {
     const parts = getFontParts(this.ctx.font, this.density);
@@ -1030,6 +1033,7 @@ export class Canvasimo {
   }
   /**
    * Get the font variant that is being used.
+   * Returns null if using a special font e.g. caption, icon, menu.
    */
   public getFontVariant = (): string | null => {
     const parts = getFontParts(this.ctx.font, this.density);
@@ -1052,6 +1056,7 @@ export class Canvasimo {
   }
   /**
    * Get the font weight that is being used.
+   * Returns null if using a special font e.g. caption, icon, menu.
    */
   public getFontWeight = (): string | number | null => {
     const parts = getFontParts(this.ctx.font, this.density);

--- a/src/index.ts
+++ b/src/index.ts
@@ -847,12 +847,12 @@ export class Canvasimo {
     return this;
   }
   /**
-   * Draw text with a stroke, wrapped at newlines and or, automatically wrapped if the text exceeds the maxWidth.
+   * Draw text with a stroke, wrapped at newlines and automatically wrapped if the text exceeds the maxWidth.
    * If no maxWidth is specified text will only wrap at newlines.
    * Words will not break by default and therefore may overflow.
    * Text is not hyphenated by default and may overflow.
-   * If the `hyphenated` parameter is `true`, `breakWord` will be ignored.
-   * The `lineHeight` parameter is a multiplier for the font size, and defaults to 1.5.
+   * If the hyphenated parameter is true, breakWord will be ignored.
+   * The lineHeight parameter is a multiplier for the font size, and defaults to 1.5.
    */
   public strokeTextWrap = (
     text: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import {
   DEFAULT_FONT,
   IMAGE_SMOOTHING_KEYS,
   INCORRECT_GET_ANGLE_ARGUMENTS,
+  MATCHES_ALL_WHITESPACE,
+  MATCHES_WORD_BREAKS,
 } from './constants';
 import {
   BooleanFalsy,
@@ -1981,13 +1983,66 @@ export class Canvasimo {
 
       return this.textWithLineBreaks(method, lines.join('\n'), x, y, lineHeight, color);
     } else if (wordBreak === 'break-word') {
+      const lines: string[] = [''];
+      const words = text.split(MATCHES_WORD_BREAKS);
+      let lineIndex = 0;
 
+      words.forEach((word, index) => {
+        let line = lines[lineIndex];
+        const { width: lineWidth } = this.getTextSize(line);
+        const { width: newLineWidth } = this.getTextSize(line + word);
+
+        if (newLineWidth < maxWidth || line.length === 0) {
+          lines[lineIndex] += word;
+        } else {
+          lines.push('');
+          lineIndex = lines.length - 1;
+
+          line = lines[lineIndex];
+
+          if (!MATCHES_ALL_WHITESPACE.test(word)) {
+            word.split('').forEach((letter, index) => {
+              const line = lines[lineIndex];
+              const { width: lineWidth } = this.getTextSize(line);
+              const { width: newLineWidth } = this.getTextSize(line + letter);
+
+              if (newLineWidth < maxWidth || line.length === 0) {
+                lines[lineIndex] += letter;
+              } else {
+                lines.push(letter);
+                lineIndex = lines.length - 1;
+              }
+            });
+          }
+        }
+      });
+
+      return this.textWithLineBreaks(method, lines.join('\n'), x, y, lineHeight, color);
     } else {
+      const lines: string[] = [''];
+      const words = text.split(MATCHES_WORD_BREAKS);
+      let lineIndex = 0;
 
+      words.forEach((word, index) => {
+        let line = lines[lineIndex];
+        const { width: lineWidth } = this.getTextSize(line);
+        const { width: newLineWidth } = this.getTextSize(line + word);
+
+        if (newLineWidth < maxWidth || line.length === 0) {
+          lines[lineIndex] += word;
+        } else {
+          if (!MATCHES_ALL_WHITESPACE.test(word)) {
+            lines.push(word);
+          } else {
+            lines.push('');
+          }
+
+          lineIndex = lines.length - 1;
+        }
+      });
+
+      return this.textWithLineBreaks(method, lines.join('\n'), x, y, lineHeight, color);
     }
-
-    method(text, x, y, undefined, color);
-    return this;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -847,6 +847,26 @@ export class Canvasimo {
     return this;
   }
   /**
+   * Draw text with a stroke, wrapped at newlines and or, automatically wrapped if the text exceeds the maxWidth.
+   * If no maxWidth is specified text will only wrap at newlines.
+   * Words will not break by default and therefore may overflow.
+   * Text is not hyphenated by default and may overflow.
+   * If the `hyphenated` parameter is `true`, `breakWord` will be ignored.
+   * The `lineHeight` parameter is a multiplier for the font size, and defaults to 1.5.
+   */
+  public strokeTextWrap = (
+    text: string,
+    x: number,
+    y: number,
+    maxWidth?: MaxWidth,
+    breakWord?: BooleanFalsy,
+    hyphenate?: BooleanFalsy,
+    lineHeight?: number
+  ): Canvasimo => {
+    // Do stuff here
+    return this;
+  }
+  /**
    * Get information about the size text will be drawn.
    * @alias measureText
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1999,12 +1999,11 @@ export class Canvasimo {
   }
   private wrapNormal = (text: string, maxWidth: number): string[] => {
     const lines: string[] = [''];
-      const words = text.split(MATCHES_WORD_BREAKS);
+    const words = text.split(MATCHES_WORD_BREAKS);
     let lineIndex = 0;
 
     words.forEach((word, index) => {
-      let line = lines[lineIndex];
-      const { width: lineWidth } = this.getTextSize(line);
+      const line = lines[lineIndex];
       const { width: newLineWidth } = this.getTextSize(line + word);
 
       if (newLineWidth < maxWidth || line.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -861,7 +861,8 @@ export class Canvasimo {
     maxWidth?: MaxWidth,
     breakWord?: BooleanFalsy,
     hyphenate?: BooleanFalsy,
-    lineHeight?: number
+    lineHeight?: number,
+    color?: string
   ): Canvasimo => {
     // Do stuff here
     return this;

--- a/src/index.ts
+++ b/src/index.ts
@@ -865,7 +865,7 @@ export class Canvasimo {
     lineHeight?: number,
     color?: string
   ): Canvasimo => {
-    return this.textWrap(
+    return this.textMultiline(
       this.strokeText,
       text,
       x,
@@ -895,7 +895,7 @@ export class Canvasimo {
     lineHeight?: number,
     color?: string
   ): Canvasimo => {
-    return this.textWrap(
+    return this.textMultiline(
       this.fillText,
       text,
       x,
@@ -1933,7 +1933,7 @@ export class Canvasimo {
     return this;
   }
   private getCanvasProperty = (attribute: string) => (this.ctx as any)[attribute];
-  private textWrap = (
+  private textMultiline = (
     method: this['strokeText'] | this['fillText'],
     text: string,
     x: number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1948,6 +1948,17 @@ export class Canvasimo {
     const definedFontSize = this.getFontSize();
     const fontSize = typeof definedFontSize === 'number' ? definedFontSize : 10;
 
+    /*
+
+    NOTES
+
+    Existing hyphens should not have additional hyphens added to them
+    Existing hyphens should remain attached which there is room
+
+    New hyphens should not be inserted if there is no room on that line (when only 1 or less characters fit)
+
+    */
+
     if (typeof maxWidth === 'undefined' || maxWidth === null) {
       const lines = text.split('\n');
       lines.forEach((line, index) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1938,7 +1938,7 @@ export class Canvasimo {
     lineHeight?: number,
     color?: string
   ): Canvasimo => {
-
+    method(text, x, y, undefined, color);
     return this;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1971,15 +1971,11 @@ export class Canvasimo {
         const { width: lineWidth } = this.getTextSize(line);
         const { width: newLineWidth } = this.getTextSize(line + letter);
 
-        // Current offset if too large put on new line
-        if (line.length >= 1 && newLineWidth > maxWidth) {
-          lineIndex += 1;
-          lines.push(letter);
-        // Current offset fits on this line
-        } else if (newLineWidth < maxWidth) {
+        if (newLineWidth < maxWidth || line.length === 0) {
           lines[lineIndex] += letter;
         } else {
           lines.push(letter);
+          lineIndex = lines.length - 1;
         }
       });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1942,8 +1942,6 @@ export class Canvasimo {
     const definedFontSize = this.getFontSize();
     const fontSize = typeof definedFontSize === 'number' ? definedFontSize : 10;
 
-    console.log(fontSize, height);
-
     if (!breakWord && !hyphenate) {
       const lines = text.split('\n');
       lines.forEach((line, index) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1997,8 +1997,7 @@ export class Canvasimo {
 
     return lines;
   }
-  private wrapNormal = (text: string, maxWidth: number): string[] => {
-    const lines: string[] = [''];
+  private wrapNormal = (text: string, maxWidth: number, lines: string[] = ['']): string[] => {
     const words = text.split(MATCHES_WORD_BREAKS);
     let lineIndex = 0;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -853,7 +853,7 @@ export class Canvasimo {
    * If no maxWidth is specified text will only wrap at newlines (wordBreak is ignore).
    * Words will not break by default (normal) and therefore may overflow.
    * break-all will break words wherever possible, and break-word will only break words if there is not enough room.
-   * The lineHeight parameter is a multiplier for the font size, and defaults to 1.5.
+   * The lineHeight parameter is a multiplier for the font size, and defaults to 1.
    */
   public strokeTextMultiline = (
     text: string,
@@ -880,7 +880,7 @@ export class Canvasimo {
    * If no maxWidth is specified text will only wrap at newlines (wordBreak is ignore).
    * Words will not break by default (normal) and therefore may overflow.
    * break-all will break words wherever possible, and break-word will only break words if there is not enough room.
-   * The lineHeight parameter is a multiplier for the font size, and defaults to 1.5.
+   * The lineHeight parameter is a multiplier for the font size, and defaults to 1.
    */
   public fillTextMultiline = (
     text: string,
@@ -1938,7 +1938,7 @@ export class Canvasimo {
     lineHeight?: number,
     color?: string
   ): Canvasimo => {
-    const height = typeof lineHeight === 'number' ? lineHeight : 1.5;
+    const height = typeof lineHeight === 'number' ? lineHeight : 1;
     const definedFontSize = this.getFontSize();
     const fontSize = typeof definedFontSize === 'number' ? definedFontSize : 10;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1950,9 +1950,14 @@ export class Canvasimo {
       });
 
       return this;
-    } else if (!breakWord && !hyphenate) {
+    } else if (wordBreak === 'break-all') {
+
+    } else if (wordBreak === 'break-word') {
+
+    } else {
 
     }
+
     method(text, x, y, undefined, color);
     return this;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ export class Canvasimo {
 
     this.density = density;
 
+    // FIXME: Test that these are correctly adjusted
     if (prevDensity !== density) {
       this.setSize(this.element.width, this.element.height);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -864,8 +864,17 @@ export class Canvasimo {
     lineHeight?: number,
     color?: string
   ): Canvasimo => {
-    // Do stuff here
-    return this;
+    return this.textWrap(
+      this.strokeText,
+      text,
+      x,
+      y,
+      maxWidth,
+      breakWord,
+      hyphenate,
+      lineHeight,
+      color
+    );
   }
   /**
    * Draw text with a fill, wrapped at newlines and automatically wrapped if the text exceeds the maxWidth.
@@ -885,8 +894,17 @@ export class Canvasimo {
     lineHeight?: number,
     color?: string
   ): Canvasimo => {
-    // Do stuff here
-    return this;
+    return this.textWrap(
+      this.fillText,
+      text,
+      x,
+      y,
+      maxWidth,
+      breakWord,
+      hyphenate,
+      lineHeight,
+      color
+    );
   }
   /**
    * Get information about the size text will be drawn.
@@ -1909,6 +1927,20 @@ export class Canvasimo {
     return this;
   }
   private getCanvasProperty = (attribute: string) => (this.ctx as any)[attribute];
+  private textWrap = (
+    method: this['strokeText'] | this['fillText'],
+    text: string,
+    x: number,
+    y: number,
+    maxWidth?: MaxWidth,
+    breakWord?: BooleanFalsy,
+    hyphenate?: BooleanFalsy,
+    lineHeight?: number,
+    color?: string
+  ): Canvasimo => {
+
+    return this;
+  }
 }
 
 export default Canvasimo;

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,13 +85,17 @@ export class Canvasimo {
   public setDensity = (density: number): Canvasimo => {
     const prevDensity = this.density;
     const multiplier = density / prevDensity;
+    const {
+      width: prevWidth,
+      height: prevHeight,
+    } = this.getSize();
     const prevFontSize = this.getFontSize();
     const prevLineDash = this.getLineDash();
 
     this.density = density;
 
     if (prevDensity !== density) {
-      this.setSize(this.element.width, this.element.height);
+      this.setSize(prevWidth, prevHeight);
 
       if (typeof prevFontSize === 'number') {
         this.setFontSize(prevFontSize);

--- a/src/index.ts
+++ b/src/index.ts
@@ -868,6 +868,27 @@ export class Canvasimo {
     return this;
   }
   /**
+   * Draw text with a fill, wrapped at newlines and automatically wrapped if the text exceeds the maxWidth.
+   * If no maxWidth is specified text will only wrap at newlines.
+   * Words will not break by default and therefore may overflow.
+   * Text is not hyphenated by default and may overflow.
+   * If the hyphenated parameter is true, breakWord will be ignored.
+   * The lineHeight parameter is a multiplier for the font size, and defaults to 1.5.
+   */
+  public fillTextWrap = (
+    text: string,
+    x: number,
+    y: number,
+    maxWidth?: MaxWidth,
+    breakWord?: BooleanFalsy,
+    hyphenate?: BooleanFalsy,
+    lineHeight?: number,
+    color?: string
+  ): Canvasimo => {
+    // Do stuff here
+    return this;
+  }
+  /**
    * Get information about the size text will be drawn.
    * @alias measureText
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,13 +84,19 @@ export class Canvasimo {
    */
   public setDensity = (density: number): Canvasimo => {
     const prevDensity = this.density;
-    const multiplier = density / prevDensity;
+
     const {
       width: prevWidth,
       height: prevHeight,
     } = this.getSize();
     const prevFontSize = this.getFontSize();
     const prevLineDash = this.getLineDash();
+    const prevLineDashOffset = this.getLineDashOffset();
+    const prevLineWidth = this.getLineWidth();
+    const prevMiterLimit = this.getMiterLimit();
+    const prevShadowBlur = this.getShadowBlur();
+    const prevShadowOffsetX = this.getShadowOffsetX();
+    const prevShadowOffsetY = this.getShadowOffsetY();
 
     this.density = density;
 
@@ -102,13 +108,12 @@ export class Canvasimo {
       }
 
       this.setLineDash(prevLineDash);
-
-      this.ctx.lineDashOffset *= multiplier;
-      this.ctx.lineWidth *= multiplier;
-      this.ctx.miterLimit *= multiplier;
-      this.ctx.shadowBlur *= multiplier;
-      this.ctx.shadowOffsetX *= multiplier;
-      this.ctx.shadowOffsetY *= multiplier;
+      this.setLineDashOffset(prevLineDashOffset);
+      this.setLineWidth(prevLineWidth);
+      this.setMiterLimit(prevMiterLimit);
+      this.setShadowBlur(prevShadowBlur);
+      this.setShadowOffsetX(prevShadowOffsetX);
+      this.setShadowOffsetY(prevShadowOffsetY);
     }
 
     return this;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1957,6 +1957,10 @@ export class Canvasimo {
 
     New hyphens should not be inserted if there is no room on that line (when only 1 or less characters fit)
 
+    Non-word characters (.,! etc) should not have a hyphen appended, even if they are broken
+
+    Words should only be split as close to half their characters as possible
+
     */
 
     if (typeof maxWidth === 'undefined' || maxWidth === null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export class Canvasimo {
     }
 
     this.ctx = ctx;
-    this.ctx.font = formatFont(ctx.font, this.density);
+    this.ctx.font = formatFont(ctx.font, this.density, true);
   }
 
   /**
@@ -941,7 +941,7 @@ export class Canvasimo {
    * Set the font to use.
    */
   public setFont = (font: string): Canvasimo => {
-    this.ctx.font = formatFont(font, this.density);
+    this.ctx.font = formatFont(font, this.density, false);
     return this;
   }
   /**
@@ -949,25 +949,25 @@ export class Canvasimo {
    * This returns the exact CanvasRenderingContext2D.font string.
    */
   public getFont = (): string => {
-    return formatFont(this.ctx.font, this.density);
+    return formatFont(this.ctx.font, this.density, true);
   }
   /**
    * Set the font family to use.
    */
   public setFontFamily = (family: string): Canvasimo => {
-    const parts = getFontParts(this.ctx.font, this.density);
+    const parts = getFontParts(this.ctx.font, this.density, true);
     if (parts.length < 5) {
       return this.setFont('');
     }
     parts[4] = family || DEFAULT_FONT[4];
-    this.ctx.font = formatFont(parts.join(' '), this.density);
+    this.ctx.font = formatFont(parts.join(' '), this.density, false);
     return this;
   }
   /**
    * Get the font that is being used.
    */
   public getFontFamily = (): string | null => {
-    const parts = getFontParts(this.ctx.font, this.density);
+    const parts = getFontParts(this.ctx.font, this.density, true);
     if (parts.length < 5) {
       return null;
     }
@@ -977,12 +977,12 @@ export class Canvasimo {
    * Set the font size to use.
    */
   public setFontSize = (size: string | number): Canvasimo => {
-    const parts = getFontParts(this.ctx.font, this.density);
+    const parts = getFontParts(this.ctx.font, this.density, true);
     if (parts.length < 5) {
       return this.setFont('');
     }
     parts[3] = (typeof size === 'number' ? size + 'px' : size) || DEFAULT_FONT[3];
-    this.ctx.font = formatFont(parts.join(' '), this.density);
+    this.ctx.font = formatFont(parts.join(' '), this.density, false);
     return this;
   }
   /**
@@ -990,7 +990,7 @@ export class Canvasimo {
    * Returns null if using a special font e.g. caption, icon, menu.
    */
   public getFontSize = (): number | null => {
-    const parts = getFontParts(this.ctx.font, this.density);
+    const parts = getFontParts(this.ctx.font, this.density, true);
     if (parts.length < 5) {
       return null;
     }
@@ -1000,12 +1000,12 @@ export class Canvasimo {
    * Set the font style to use.
    */
   public setFontStyle = (style: string): Canvasimo => {
-    const parts = getFontParts(this.ctx.font, this.density);
+    const parts = getFontParts(this.ctx.font, this.density, true);
     if (parts.length < 5) {
       return this.setFont('');
     }
     parts[0] = style || DEFAULT_FONT[0];
-    this.ctx.font = formatFont(parts.join(' '), this.density);
+    this.ctx.font = formatFont(parts.join(' '), this.density, false);
     return this;
   }
   /**
@@ -1013,7 +1013,7 @@ export class Canvasimo {
    * Returns null if using a special font e.g. caption, icon, menu.
    */
   public getFontStyle = (): string | null => {
-    const parts = getFontParts(this.ctx.font, this.density);
+    const parts = getFontParts(this.ctx.font, this.density, true);
     if (parts.length < 5) {
       return null;
     }
@@ -1023,12 +1023,12 @@ export class Canvasimo {
    * Set the font variant to use.
    */
   public setFontVariant = (variant: string): Canvasimo => {
-    const parts = getFontParts(this.ctx.font, this.density);
+    const parts = getFontParts(this.ctx.font, this.density, true);
     if (parts.length < 5) {
       return this.setFont('');
     }
     parts[1] = variant || DEFAULT_FONT[1];
-    this.ctx.font = formatFont(parts.join(' '), this.density);
+    this.ctx.font = formatFont(parts.join(' '), this.density, false);
     return this;
   }
   /**
@@ -1036,7 +1036,7 @@ export class Canvasimo {
    * Returns null if using a special font e.g. caption, icon, menu.
    */
   public getFontVariant = (): string | null => {
-    const parts = getFontParts(this.ctx.font, this.density);
+    const parts = getFontParts(this.ctx.font, this.density, true);
     if (parts.length < 5) {
       return null;
     }
@@ -1046,12 +1046,12 @@ export class Canvasimo {
    * Set the font weight to use.
    */
   public setFontWeight = (weight: string | number): Canvasimo => {
-    const parts = getFontParts(this.ctx.font, this.density);
+    const parts = getFontParts(this.ctx.font, this.density, true);
     if (parts.length < 5) {
       return this.setFont('');
     }
     parts[2] = weight.toString() || DEFAULT_FONT[2];
-    this.ctx.font = formatFont(parts.join(' '), this.density);
+    this.ctx.font = formatFont(parts.join(' '), this.density, false);
     return this;
   }
   /**
@@ -1059,7 +1059,7 @@ export class Canvasimo {
    * Returns null if using a special font e.g. caption, icon, menu.
    */
   public getFontWeight = (): string | number | null => {
-    const parts = getFontParts(this.ctx.font, this.density);
+    const parts = getFontParts(this.ctx.font, this.density, true);
     if (parts.length < 5) {
       return null;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1938,6 +1938,21 @@ export class Canvasimo {
     lineHeight?: number,
     color?: string
   ): Canvasimo => {
+    const height = typeof lineHeight === 'number' ? lineHeight : 1.5;
+    const definedFontSize = this.getFontSize();
+    const fontSize = typeof definedFontSize === 'number' ? definedFontSize : 10;
+
+    console.log(fontSize, height);
+
+    if (!breakWord && !hyphenate) {
+      const lines = text.split('\n');
+      lines.forEach((line, index) => {
+        const offset = fontSize * height;
+        method(line, x, y + offset * index, undefined, color);
+      });
+
+      return this;
+    }
     method(text, x, y, undefined, color);
     return this;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
   Stroke,
   TextAlign,
   TextBaseline,
+  WordBreak,
 } from './types';
 import {
   formatFont,
@@ -849,10 +850,9 @@ export class Canvasimo {
   }
   /**
    * Draw text with a stroke, wrapped at newlines and automatically wrapped if the text exceeds the maxWidth.
-   * If no maxWidth is specified text will only wrap at newlines (breakWord and hyphenate are ignored).
-   * Words will not break by default and therefore may overflow.
-   * Text is not hyphenated by default and may overflow.
-   * If the hyphenated parameter is true, breakWord will be ignored.
+   * If no maxWidth is specified text will only wrap at newlines (wordBreak is ignore).
+   * Words will not break by default (normal) and therefore may overflow.
+   * break-all will break words wherever possible, and break-word will only break words if there is not enough room.
    * The lineHeight parameter is a multiplier for the font size, and defaults to 1.5.
    */
   public strokeTextMultiline = (
@@ -860,8 +860,7 @@ export class Canvasimo {
     x: number,
     y: number,
     maxWidth?: MaxWidth,
-    breakWord?: BooleanFalsy,
-    hyphenate?: BooleanFalsy,
+    wordBreak?: WordBreak,
     lineHeight?: number,
     color?: string
   ): Canvasimo => {
@@ -871,18 +870,16 @@ export class Canvasimo {
       x,
       y,
       maxWidth,
-      breakWord,
-      hyphenate,
+      wordBreak,
       lineHeight,
       color
     );
   }
   /**
    * Draw text with a fill, wrapped at newlines and automatically wrapped if the text exceeds the maxWidth.
-   * If no maxWidth is specified text will only wrap at newlines (breakWord and hyphenate are ignored).
-   * Words will not break by default and therefore may overflow.
-   * Text is not hyphenated by default and may overflow.
-   * If the hyphenated parameter is true, breakWord will be ignored.
+   * If no maxWidth is specified text will only wrap at newlines (wordBreak is ignore).
+   * Words will not break by default (normal) and therefore may overflow.
+   * break-all will break words wherever possible, and break-word will only break words if there is not enough room.
    * The lineHeight parameter is a multiplier for the font size, and defaults to 1.5.
    */
   public fillTextMultiline = (
@@ -890,8 +887,7 @@ export class Canvasimo {
     x: number,
     y: number,
     maxWidth?: MaxWidth,
-    breakWord?: BooleanFalsy,
-    hyphenate?: BooleanFalsy,
+    wordBreak?: WordBreak,
     lineHeight?: number,
     color?: string
   ): Canvasimo => {
@@ -901,8 +897,7 @@ export class Canvasimo {
       x,
       y,
       maxWidth,
-      breakWord,
-      hyphenate,
+      wordBreak,
       lineHeight,
       color
     );
@@ -1939,29 +1934,13 @@ export class Canvasimo {
     x: number,
     y: number,
     maxWidth?: MaxWidth,
-    breakWord?: BooleanFalsy,
-    hyphenate?: BooleanFalsy,
+    wordBreak?: WordBreak,
     lineHeight?: number,
     color?: string
   ): Canvasimo => {
     const height = typeof lineHeight === 'number' ? lineHeight : 1.5;
     const definedFontSize = this.getFontSize();
     const fontSize = typeof definedFontSize === 'number' ? definedFontSize : 10;
-
-    /*
-
-    NOTES
-
-    Existing hyphens should not have additional hyphens added to them
-    Existing hyphens should remain attached which there is room
-
-    New hyphens should not be inserted if there is no room on that line (when only 1 or less characters fit)
-
-    Non-word characters (.,! etc) should not have a hyphen appended, even if they are broken
-
-    Words should only be split as close to half their characters as possible
-
-    */
 
     if (typeof maxWidth === 'undefined' || maxWidth === null) {
       const lines = text.split('\n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -849,7 +849,7 @@ export class Canvasimo {
   }
   /**
    * Draw text with a stroke, wrapped at newlines and automatically wrapped if the text exceeds the maxWidth.
-   * If no maxWidth is specified text will only wrap at newlines.
+   * If no maxWidth is specified text will only wrap at newlines (breakWord and hyphenate are ignored).
    * Words will not break by default and therefore may overflow.
    * Text is not hyphenated by default and may overflow.
    * If the hyphenated parameter is true, breakWord will be ignored.
@@ -879,7 +879,7 @@ export class Canvasimo {
   }
   /**
    * Draw text with a fill, wrapped at newlines and automatically wrapped if the text exceeds the maxWidth.
-   * If no maxWidth is specified text will only wrap at newlines.
+   * If no maxWidth is specified text will only wrap at newlines (breakWord and hyphenate are ignored).
    * Words will not break by default and therefore may overflow.
    * Text is not hyphenated by default and may overflow.
    * If the hyphenated parameter is true, breakWord will be ignored.
@@ -1948,7 +1948,7 @@ export class Canvasimo {
     const definedFontSize = this.getFontSize();
     const fontSize = typeof definedFontSize === 'number' ? definedFontSize : 10;
 
-    if (!breakWord && !hyphenate) {
+    if (typeof maxWidth === 'undefined' || maxWidth === null) {
       const lines = text.split('\n');
       lines.forEach((line, index) => {
         const offset = fontSize * height;
@@ -1956,6 +1956,8 @@ export class Canvasimo {
       });
 
       return this;
+    } else if (!breakWord && !hyphenate) {
+
     }
     method(text, x, y, undefined, color);
     return this;

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export type LineJoin = 'bevel' | 'round' | 'miter';
 export type LineCap = 'butt' | 'round' | 'square';
 export type FillRule = 'nonzero' | 'evenodd';
 export type BooleanFalsy = boolean | undefined | null;
+export type MaxWidth = number | undefined | null;
 
 export type ImageLike = HTMLImageElement | HTMLCanvasElement | HTMLVideoElement | ImageBitmap;
 export type CanvasContextAttributes = Canvas2DContextAttributes | WebGLContextAttributes;

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type TextAlign = 'left' | 'right' | 'center' | 'start' | 'end';
 export type LineJoin = 'bevel' | 'round' | 'miter';
 export type LineCap = 'butt' | 'round' | 'square';
 export type FillRule = 'nonzero' | 'evenodd';
+export type WordBreak = 'normal' | 'break-word' | 'break-all'
 export type BooleanFalsy = boolean | undefined | null;
 export type MaxWidth = number | undefined | null;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export type TextAlign = 'left' | 'right' | 'center' | 'start' | 'end';
 export type LineJoin = 'bevel' | 'round' | 'miter';
 export type LineCap = 'butt' | 'round' | 'square';
 export type FillRule = 'nonzero' | 'evenodd';
-export type WordBreak = 'normal' | 'break-word' | 'break-all'
+export type WordBreak = 'normal' | 'break-word' | 'break-all';
 export type BooleanFalsy = boolean | undefined | null;
 export type MaxWidth = number | undefined | null;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,7 +51,6 @@ export const getFontParts = (input: string | undefined, density: number, getter:
   const lineHeight = matchFontSize[4];
 
   if (lineHeight && !warnedAboutLineHeight) {
-    // FIXME: Test for warning
     // tslint:disable-next-line:no-console
     console.warn(
       `Attempted to set the font line height with "${fontString}", ` +

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,7 +55,8 @@ export const getFontParts = (input: string | undefined, density: number, getter:
     // tslint:disable-next-line:no-console
     console.warn(
       `Attempted to set the font line height with "${fontString}", ` +
-      'but this is not supported by canvas. Use the Canvasimo TextWrap methods with the lineHeight parameter instead.'
+      'but this is not supported by canvas. ' +
+      'Use the Canvasimo TextMultiline methods with the lineHeight parameter instead.'
     );
     warnedAboutLineHeight = true;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,6 +51,7 @@ export const getFontParts = (input: string | undefined, density: number) => {
   const lineHeight = matchFontSize[4];
 
   if (lineHeight && !warnedAboutLineHeight) {
+    // FIXME: Test for warning
     // tslint:disable-next-line:no-console
     console.warn(
       `Attempted to set the font line height with "${fontString}", ` +

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -44,13 +44,14 @@ export const getFontParts = (input: string | undefined, density: number) => {
     return DEFAULT_FONT;
   }
 
-  const fontString = matchFontSize[0].trim()
+  const fontString = matchFontSize[0].trim();
   const leadingSpaces = matchFontSize[1].length;
   const size = matchFontSize[2];
   const unit = matchFontSize[3];
   const lineHeight = matchFontSize[4];
 
   if (lineHeight && !warnedAboutLineHeight) {
+    // tslint:disable-next-line:no-console
     console.warn(
       `Attempted to set the font line height with "${fontString}", ` +
       'but this is not supported by canvas. Use the Canvasimo TextWrap methods with the lineHeight parameter instead.'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -27,7 +27,7 @@ export const isTuplePoint = (point?: {x: number, y: number} | [number, number] |
 
 let warnedAboutLineHeight = false;
 
-export const getFontParts = (input: string | undefined, density: number) => {
+export const getFontParts = (input: string | undefined, density: number, getter: boolean) => {
   if (!input) {
     return DEFAULT_FONT;
   }
@@ -60,7 +60,7 @@ export const getFontParts = (input: string | undefined, density: number) => {
     warnedAboutLineHeight = true;
   }
 
-  const fontSize = (unit !== '%' ? parseFloat(size) * density : size) + unit;
+  const fontSize = (unit !== '%' ? (getter ? parseFloat(size) / density : parseFloat(size) * density) : size) + unit;
 
   const parts = font.substring(matchFontSize.index + leadingSpaces).split(MATCHES_WHITESPACE);
   const fontFamily = parts[parts.length - 1];
@@ -97,7 +97,8 @@ export const getFontParts = (input: string | undefined, density: number) => {
   ];
 };
 
-export const formatFont = (input: string, density: number): string => getFontParts(input, density).join(' ');
+export const formatFont = (input: string, density: number, getter: boolean): string =>
+  getFontParts(input, density, getter).join(' ');
 
 export const forPoints = (points: Points, callback: (x: number, y: number, index: number) => any): void => {
   if (!Array.isArray(points) || (typeof points[0] === 'number' && (points.length % 2) !== 0)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,8 @@ export const isTuplePoint = (point?: {x: number, y: number} | [number, number] |
   return typeof point === 'object' && Array.isArray(point) && point.length === 2;
 };
 
+let warnedAboutLineHeight = false;
+
 export const getFontParts = (input: string | undefined, density: number) => {
   if (!input) {
     return DEFAULT_FONT;
@@ -42,9 +44,19 @@ export const getFontParts = (input: string | undefined, density: number) => {
     return DEFAULT_FONT;
   }
 
+  const fontString = matchFontSize[0].trim()
   const leadingSpaces = matchFontSize[1].length;
   const size = matchFontSize[2];
   const unit = matchFontSize[3];
+  const lineHeight = matchFontSize[4];
+
+  if (lineHeight && !warnedAboutLineHeight) {
+    console.warn(
+      `Attempted to set the font line height with "${fontString}", ` +
+      'but this is not supported by canvas. Use the Canvasimo TextWrap methods with the lineHeight parameter instead.'
+    );
+    warnedAboutLineHeight = true;
+  }
 
   const fontSize = (unit !== '%' ? parseFloat(size) * density : size) + unit;
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -246,6 +246,93 @@ describe('canvasimo', () => {
 
   });
 
+  describe('setDensity', () => {
+
+    it('should adjust canvas context properties when changing the density', () => {
+      const ctx = canvas.getCurrentContext();
+
+      canvas
+        .setDensity(1)
+        .setWidth(1)
+        .setHeight(1)
+        .setFontSize(1)
+        .setLineDashOffset(1)
+        .setLineWidth(1)
+        .setMiterLimit(1)
+        .setShadowBlur(1)
+        .setShadowOffsetX(1)
+        .setShadowOffsetY(1);
+
+      expect(canvas.getDensity()).toBe(1);
+      expect(canvas.getWidth()).toBe(1);
+      expect(canvas.getHeight()).toBe(1);
+      expect(canvas.getFontSize()).toBe(1);
+      expect(canvas.getLineDashOffset()).toBe(1);
+      expect(canvas.getLineWidth()).toBe(1);
+      expect(canvas.getMiterLimit()).toBe(1);
+      expect(canvas.getShadowBlur()).toBe(1);
+      expect(canvas.getShadowOffsetX()).toBe(1);
+      expect(canvas.getShadowOffsetY()).toBe(1);
+
+      expect(element.width).toBe(1);
+      expect(element.height).toBe(1);
+      expect(ctx.font).toBe('normal normal normal 1px sans-serif');
+      expect(ctx.lineDashOffset).toBe(1);
+      expect(ctx.lineWidth).toBe(1);
+      expect(ctx.miterLimit).toBe(1);
+      expect(ctx.shadowBlur).toBe(1);
+      expect(ctx.shadowOffsetX).toBe(1);
+      expect(ctx.shadowOffsetY).toBe(1);
+
+      canvas.setDensity(2);
+
+      expect(canvas.getDensity()).toBe(2);
+      expect(canvas.getWidth()).toBe(1);
+      expect(canvas.getHeight()).toBe(1);
+      expect(canvas.getFontSize()).toBe(1);
+      expect(canvas.getLineDashOffset()).toBe(1);
+      expect(canvas.getLineWidth()).toBe(1);
+      expect(canvas.getMiterLimit()).toBe(1);
+      expect(canvas.getShadowBlur()).toBe(1);
+      expect(canvas.getShadowOffsetX()).toBe(1);
+      expect(canvas.getShadowOffsetY()).toBe(1);
+
+      expect(element.width).toBe(2);
+      expect(element.height).toBe(2);
+      expect(ctx.font).toBe('normal normal normal 2px sans-serif');
+      expect(ctx.lineDashOffset).toBe(2);
+      expect(ctx.lineWidth).toBe(2);
+      expect(ctx.miterLimit).toBe(2);
+      expect(ctx.shadowBlur).toBe(2);
+      expect(ctx.shadowOffsetX).toBe(2);
+      expect(ctx.shadowOffsetY).toBe(2);
+
+      canvas.setDensity(1);
+
+      expect(canvas.getDensity()).toBe(1);
+      expect(canvas.getWidth()).toBe(1);
+      expect(canvas.getHeight()).toBe(1);
+      expect(canvas.getFontSize()).toBe(1);
+      expect(canvas.getLineDashOffset()).toBe(1);
+      expect(canvas.getLineWidth()).toBe(1);
+      expect(canvas.getMiterLimit()).toBe(1);
+      expect(canvas.getShadowBlur()).toBe(1);
+      expect(canvas.getShadowOffsetX()).toBe(1);
+      expect(canvas.getShadowOffsetY()).toBe(1);
+
+      expect(element.width).toBe(1);
+      expect(element.height).toBe(1);
+      expect(ctx.font).toBe('normal normal normal 1px sans-serif');
+      expect(ctx.lineDashOffset).toBe(1);
+      expect(ctx.lineWidth).toBe(1);
+      expect(ctx.miterLimit).toBe(1);
+      expect(ctx.shadowBlur).toBe(1);
+      expect(ctx.shadowOffsetX).toBe(1);
+      expect(ctx.shadowOffsetY).toBe(1);
+    });
+
+  });
+
   describe('font methods', () => {
 
     it('should return a formatted font value', () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -84,6 +84,10 @@ describe('canvasimo', () => {
     mockClearAll();
   });
 
+  afterEach(() => {
+    canvas.setDensity(1);
+  });
+
   it('should return an interface', () => {
     jest.spyOn(element, 'getContext').mockImplementation(getContextStub);
     jest.spyOn(element, 'getBoundingClientRect').mockImplementation(getBoundingClientRectStub);
@@ -379,8 +383,6 @@ describe('canvasimo', () => {
 
       expect(canvas.getFontFamily()).toBe('arial');
       expect(canvas.getFontSize()).toBe(5);
-
-      canvas.setDensity(1);
     });
 
   });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -73,6 +73,9 @@ describe('canvasimo', () => {
     plotClosedPath: [[]],
     fillClosedPath: [[]],
     strokeClosedPath: [[]],
+    strokeTextWrap: ['', 0, 0],
+    fillTextWrap: ['', 0, 0],
+    textWrap: [jest.fn(), '', 0, 0],
   };
 
   const isGetter = /^(get|create|is|measure|constrain|map|version)/i;

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -89,7 +89,9 @@ describe('canvasimo', () => {
   });
 
   afterEach(() => {
-    canvas.setDensity(1);
+    canvas
+      .setDensity(1)
+      .setFontSize('invalid');
   });
 
   it('should return an interface', () => {
@@ -265,6 +267,8 @@ describe('canvasimo', () => {
     });
 
     it('should return individual font properties', () => {
+      canvas.setFont('normal small-caps bold 20px arial');
+
       expect(canvas.getFontStyle()).toBe('normal');
       expect(canvas.getFontVariant()).toBe('small-caps');
       expect(canvas.getFontWeight()).toBe('bold');
@@ -273,6 +277,9 @@ describe('canvasimo', () => {
     });
 
     it('should set individual font properties', () => {
+      canvas.setFont('normal small-caps bold 20px arial');
+      expect(canvas.getFont()).toBe('normal small-caps bold 20px arial');
+
       canvas.setFontStyle('italic');
       expect(canvas.getFont()).toBe('italic small-caps bold 20px arial');
 
@@ -297,6 +304,8 @@ describe('canvasimo', () => {
     });
 
     it('should return null for individual properties when a special font is set', () => {
+      canvas.setFont('menu');
+
       expect(canvas.getFontStyle()).toBe(null);
       expect(canvas.getFontVariant()).toBe(null);
       expect(canvas.getFontWeight()).toBe(null);

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -365,34 +365,80 @@ describe('canvasimo', () => {
       canvas.setDensity(1);
       canvas.setFont('10px arial');
 
-      expect(canvas.getFont()).toBe('10px arial');
+      expect(canvas.getFont()).toBe('normal normal normal 10px arial');
       expect(canvas.getFontFamily()).toBe('arial');
       expect(canvas.getFontSize()).toBe(10);
 
       canvas.setFontSize(5);
 
-      expect(canvas.getFont()).toBe('5px arial');
+      expect(canvas.getFont()).toBe('normal normal normal 5px arial');
       expect(canvas.getFontFamily()).toBe('arial');
       expect(canvas.getFontSize()).toBe(5);
 
       canvas.setDensity(2);
       canvas.setFont('10px arial');
 
-      expect(canvas.getFont()).toBe('10px arial');
+      expect(canvas.getFont()).toBe('normal normal normal 10px arial');
       expect(canvas.getFontFamily()).toBe('arial');
       expect(canvas.getFontSize()).toBe(10);
 
       canvas.setFontSize(5);
 
-      expect(canvas.getFont()).toBe('5px arial');
+      expect(canvas.getFont()).toBe('normal normal normal 5px arial');
       expect(canvas.getFontFamily()).toBe('arial');
       expect(canvas.getFontSize()).toBe(5);
 
       canvas.setDensity(1);
 
-      expect(canvas.getFont()).toBe('5px arial');
+      expect(canvas.getFont()).toBe('normal normal normal 5px arial');
       expect(canvas.getFontFamily()).toBe('arial');
       expect(canvas.getFontSize()).toBe(5);
+
+      canvas.setFontWeight(300);
+
+      expect(canvas.getFont()).toBe('normal normal 300 5px arial');
+      expect(canvas.getFontFamily()).toBe('arial');
+      expect(canvas.getFontSize()).toBe(5);
+
+      canvas.setDensity(2);
+
+      expect(canvas.getFont()).toBe('normal normal 300 5px arial');
+      expect(canvas.getFontFamily()).toBe('arial');
+      expect(canvas.getFontSize()).toBe(5);
+
+      canvas.setFontWeight(600);
+
+      expect(canvas.getFont()).toBe('normal normal 600 5px arial');
+      expect(canvas.getFontFamily()).toBe('arial');
+      expect(canvas.getFontSize()).toBe(5);
+
+      canvas.setDensity(1);
+      canvas.setFontSize(50);
+
+      expect(canvas.getFont()).toBe('normal normal 600 50px arial');
+      expect(canvas.getFontFamily()).toBe('arial');
+      expect(canvas.getFontSize()).toBe(50);
+
+      canvas.setDensity(2);
+      canvas.setFontSize('5em');
+
+      expect(canvas.getFont()).toBe('normal normal 600 5em arial');
+      expect(canvas.getFontFamily()).toBe('arial');
+      expect(canvas.getFontSize()).toBe(5);
+
+      canvas.setDensity(2);
+      canvas.setFontSize('70%');
+
+      expect(canvas.getFont()).toBe('normal normal 600 70% arial');
+      expect(canvas.getFontFamily()).toBe('arial');
+      expect(canvas.getFontSize()).toBe(70);
+
+      canvas.setDensity(1);
+      canvas.setFontSize('70%');
+
+      expect(canvas.getFont()).toBe('normal normal 600 70% arial');
+      expect(canvas.getFontFamily()).toBe('arial');
+      expect(canvas.getFontSize()).toBe(70);
     });
 
   });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -73,12 +73,16 @@ describe('canvasimo', () => {
     plotClosedPath: [[]],
     fillClosedPath: [[]],
     strokeClosedPath: [[]],
-    strokeTextWrap: ['', 0, 0],
-    fillTextWrap: ['', 0, 0],
-    textWrap: [jest.fn(), '', 0, 0],
+    strokeTextMultiline: ['', 0, 0],
+    fillTextMultiline: ['', 0, 0],
+    drawTextWithLineBreaks: [jest.fn(), '', 0, 0],
+    wrapBreakAll: ['', 100],
+    wrapBreakWord: ['', 100],
+    wrapNormal: ['', 100],
+    textMultiline: [jest.fn(), '', 0, 0],
   };
 
-  const isGetter = /^(get|create|is|measure|constrain|map|version)/i;
+  const isGetter = /^(get|create|is|measure|constrain|map|version|wrapBreakAll|wrapBreakWord|wrapNormal)/i;
 
   beforeEach(() => {
     mockClearAll();

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -137,7 +137,7 @@ describe('canvasimo', () => {
 
     it('should return the actual canvas context', () => {
       expect(canvas.getContext('2d')).toBe(element.getContext('2d'));
-      expect(canvas.getContext('someothercontext')).toEqual({});
+      expect(canvas.getContext('SomeOtherContext')).toEqual({});
       expect(canvas.getContext('')).toEqual({});
     });
 

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -365,27 +365,32 @@ describe('canvasimo', () => {
       canvas.setDensity(1);
       canvas.setFont('10px arial');
 
+      expect(canvas.getFont()).toBe('10px arial');
       expect(canvas.getFontFamily()).toBe('arial');
       expect(canvas.getFontSize()).toBe(10);
 
       canvas.setFontSize(5);
 
+      expect(canvas.getFont()).toBe('5px arial');
       expect(canvas.getFontFamily()).toBe('arial');
       expect(canvas.getFontSize()).toBe(5);
 
       canvas.setDensity(2);
       canvas.setFont('10px arial');
 
+      expect(canvas.getFont()).toBe('10px arial');
       expect(canvas.getFontFamily()).toBe('arial');
       expect(canvas.getFontSize()).toBe(10);
 
       canvas.setFontSize(5);
 
+      expect(canvas.getFont()).toBe('5px arial');
       expect(canvas.getFontFamily()).toBe('arial');
       expect(canvas.getFontSize()).toBe(5);
 
       canvas.setDensity(1);
 
+      expect(canvas.getFont()).toBe('5px arial');
       expect(canvas.getFontFamily()).toBe('arial');
       expect(canvas.getFontSize()).toBe(5);
     });

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -357,6 +357,32 @@ describe('canvasimo', () => {
       expect(canvas.getFont()).toBe('normal normal normal 10px sans-serif');
     });
 
+    it('should handle canvas density when setting and getting font sizes', () => {
+      canvas.setDensity(1);
+      canvas.setFont('10px arial');
+
+      expect(canvas.getFontFamily()).toBe('arial');
+      expect(canvas.getFontSize()).toBe(10);
+
+      canvas.setFontSize(5);
+
+      expect(canvas.getFontFamily()).toBe('arial');
+      expect(canvas.getFontSize()).toBe(5);
+
+      canvas.setDensity(2);
+      canvas.setFont('10px arial');
+
+      expect(canvas.getFontFamily()).toBe('arial');
+      expect(canvas.getFontSize()).toBe(10);
+
+      canvas.setFontSize(5);
+
+      expect(canvas.getFontFamily()).toBe('arial');
+      expect(canvas.getFontSize()).toBe(5);
+
+      canvas.setDensity(1);
+    });
+
   });
 
   describe('plot path', () => {

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -383,6 +383,11 @@ describe('canvasimo', () => {
 
       expect(canvas.getFontFamily()).toBe('arial');
       expect(canvas.getFontSize()).toBe(5);
+
+      canvas.setDensity(1);
+
+      expect(canvas.getFontFamily()).toBe('arial');
+      expect(canvas.getFontSize()).toBe(5);
     });
 
   });

--- a/tests/inspect.ts
+++ b/tests/inspect.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
-const NUMBER_OF_PROPERTIES = 186;
+const NUMBER_OF_PROPERTIES = 189;
 const CLASS_NAME = 'Canvasimo';
 const CWD = process.cwd();
 const SOURCE_FILE = fs.readFileSync(path.join(CWD, 'src/index.ts'), 'utf8');

--- a/tests/inspect.ts
+++ b/tests/inspect.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as ts from 'typescript';
 
-const NUMBER_OF_PROPERTIES = 189;
+const NUMBER_OF_PROPERTIES = 193;
 const CLASS_NAME = 'Canvasimo';
 const CWD = process.cwd();
 const SOURCE_FILE = fs.readFileSync(path.join(CWD, 'src/index.ts'), 'utf8');

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -38,11 +38,25 @@ describe('utils', () => {
   describe('getFontParts', () => {
 
     it('should return a font part array', () => {
-      expect(getFontParts('arial 20px', 1, true)).toEqual(['normal', 'normal', 'normal', '10px', 'sans-serif']);
-      expect(getFontParts('20px arial', 1, true)).toEqual(['normal', 'normal', 'normal', '20px', 'arial']);
-      expect(getFontParts('bold 20px arial', 1, true)).toEqual(['normal', 'normal', 'bold', '20px', 'arial']);
-      expect(getFontParts('italic 20px arial', 1, true)).toEqual(['italic', 'normal', 'normal', '20px', 'arial']);
-      expect(getFontParts('menu', 1, true)).toEqual(['menu']);
+      expect(getFontParts('arial 20px', 1, true))
+        .toEqual(['normal', 'normal', 'normal', '10px', 'sans-serif']);
+      expect(getFontParts('20px arial', 1, true))
+        .toEqual(['normal', 'normal', 'normal', '20px', 'arial']);
+      expect(getFontParts('bold 20px arial', 1, true))
+        .toEqual(['normal', 'normal', 'bold', '20px', 'arial']);
+      expect(getFontParts('small-caps 20px arial', 1, true))
+        .toEqual(['normal', 'small-caps', 'normal', '20px', 'arial']);
+      expect(getFontParts('italic 20px arial', 1, true))
+        .toEqual(['italic', 'normal', 'normal', '20px', 'arial']);
+      expect(getFontParts('300 italic 20px arial', 1, true))
+        .toEqual(['italic', 'normal', '300', '20px', 'arial']);
+      expect(getFontParts('menu', 1, true))
+        .toEqual(['menu']);
+    });
+
+    it('should account for density when getting or setting font parts', () => {
+      expect(getFontParts('20px arial', 2, true)).toEqual(['normal', 'normal', 'normal', '10px', 'arial']);
+      expect(getFontParts('20px arial', 2, false)).toEqual(['normal', 'normal', 'normal', '40px', 'arial']);
     });
 
   });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,4 +1,4 @@
-import { forPoints } from '../src/utils';
+import { forPoints, getFontParts } from '../src/utils';
 import { each, some } from './helpers/utils';
 
 describe('utils', () => {
@@ -31,6 +31,18 @@ describe('utils', () => {
       expect(() => forPoints([0, 1, 2, 3, 4], spy)).toThrow(anError);
       expect(() => forPoints([0, 1, 2, 'wat'] as any, spy)).toThrow(numberError);
       expect(() => forPoints([{}, {}] as any, spy)).toThrow(anError);
+    });
+
+  });
+
+  describe('getFontParts', () => {
+
+    it('should return a font part array', () => {
+      expect(getFontParts('arial 20px', 1, true)).toEqual(['normal', 'normal', 'normal', '10px', 'sans-serif']);
+      expect(getFontParts('20px arial', 1, true)).toEqual(['normal', 'normal', 'normal', '20px', 'arial']);
+      expect(getFontParts('bold 20px arial', 1, true)).toEqual(['normal', 'normal', 'bold', '20px', 'arial']);
+      expect(getFontParts('italic 20px arial', 1, true)).toEqual(['italic', 'normal', 'normal', '20px', 'arial']);
+      expect(getFontParts('menu', 1, true)).toEqual(['menu']);
     });
 
   });

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -3,6 +3,12 @@ import { each, some } from './helpers/utils';
 
 describe('utils', () => {
 
+  jest.spyOn(console, 'warn').mockImplementation(jest.fn());
+
+  beforeEach(() => {
+    (console.warn as jest.Mock<any>).mockClear();
+  });
+
   describe('forPoints', () => {
 
     it('should accept but do nothing with empty and near empty point arrays', () => {
@@ -37,10 +43,29 @@ describe('utils', () => {
 
   describe('getFontParts', () => {
 
+    it('should warn about using line height when setting fonts', () => {
+      expect(console.warn).not.toHaveBeenCalled();
+
+      getFontParts('10px/1 arial', 1, true);
+
+      expect(console.warn).toHaveBeenCalledTimes(1);
+
+      const { calls } = (console.warn as jest.Mock<any>).mock;
+
+      expect(calls[0].length).toBe(1);
+      expect(calls[0][0]).toMatch(/10px\/1.+TextMultiline.+lineHeight/);
+
+      getFontParts('10px/1 arial', 1, true);
+
+      expect(console.warn).toHaveBeenCalledTimes(1);
+    });
+
     it('should return a font part array', () => {
       expect(getFontParts('arial 20px', 1, true))
         .toEqual(['normal', 'normal', 'normal', '10px', 'sans-serif']);
       expect(getFontParts('20px arial', 1, true))
+        .toEqual(['normal', 'normal', 'normal', '20px', 'arial']);
+      expect(getFontParts('20px/2 arial', 1, true))
         .toEqual(['normal', 'normal', 'normal', '20px', 'arial']);
       expect(getFontParts('bold 20px arial', 1, true))
         .toEqual(['normal', 'normal', 'bold', '20px', 'arial']);


### PR DESCRIPTION
Line heights are not supported by canvas, so instead I warn if a user tries to set the line height in the font string, and recommend they use the TextMultiline methods.

Fixes #13 
Resolves #86 

<img width="677" alt="screen shot 2018-03-01 at 01 27 12" src="https://user-images.githubusercontent.com/5850625/36822421-dfdb1a5c-1cef-11e8-9a3c-bde1fbb61828.png">

![multiline-text](https://user-images.githubusercontent.com/5850625/36822429-e73808fa-1cef-11e8-835b-3294d89a01b3.gif)
