### PR TITLE
v0.8.0 Context value consistency (initial values and retaining state)

### DIFF
--- a/docs/src/ts/components/document.tsx
+++ b/docs/src/ts/components/document.tsx
@@ -191,7 +191,7 @@ export default class Document extends Component<Props, {}> {
                 </p>
 
                 <p>
-                  Along the way, I realised that a lot of the canvas attributes & methods were not very idiomatic,
+                  Along the way, I realized that a lot of the canvas attributes & methods were not very idiomatic,
                   and so I came up with some more suitable method / attribute names.
                 </p>
 
@@ -218,6 +218,14 @@ export default class Document extends Component<Props, {}> {
                   e.g. <code>fillRect(0, 0, 10, 10, 'black')</code>, <code>strokeLine(0, 0, 0, 20, 'red')</code>.
                   And similarly, the fill and stroke methods can now be passed a color; <code>fill('red')</code>, <code>
                     stroke('green')</code>, <code>fillCanvas('blue')</code>.
+                </p>
+
+                <p>
+                  The most recent change in Canvasimo <code>0.8.0</code> is that Canvasimo saves and retains the context
+                  state when resizing or clearing the canvas. This means that it's not always necessary to explicitly
+                  set values like font size, line width, and color in every draw loop - if you only ever use one font
+                  you can simply set this once when you're initializing Canvasimo and calls to <code>clearCanvas</code>,
+                  <code>setSize</code>, etc will not reset these values.
                 </p>
 
                 <LinkHeader type="h2" header="Examples" />

--- a/docs/src/ts/components/document.tsx
+++ b/docs/src/ts/components/document.tsx
@@ -171,6 +171,9 @@ export default class Document extends Component<Props, {}> {
                   <li>
                     Useful helper functions
                   </li>
+                  <li>
+                    Retain context state when resizing / clearing the canvas
+                  </li>
                 </ul>
 
                 <LinkHeader type="h2" header="About" />

--- a/docs/src/ts/demo.ts
+++ b/docs/src/ts/demo.ts
@@ -10,7 +10,10 @@ if (!element) {
 }
 
 const parentElement = element.parentElement;
-const canvas = new Canvasimo(element as HTMLCanvasElement).setDensity(2);
+const canvas = new Canvasimo(element as HTMLCanvasElement)
+  .setDensity(2)
+  .setStrokeCap('round')
+  .setStrokeJoin('round');
 
 canvas.version(true);
 
@@ -97,8 +100,6 @@ const draw = () => {
 
   canvas
     .clearCanvas()
-    .setStrokeCap('round')
-    .setStrokeJoin('round')
     .translate(canvas.getWidth() / 2, canvas.getHeight());
 
   const treeDone = drawBranch(tree, 0, 6);

--- a/docs/src/ts/demo.ts
+++ b/docs/src/ts/demo.ts
@@ -11,7 +11,7 @@ if (!element) {
 
 const parentElement = element.parentElement;
 const canvas = new Canvasimo(element as HTMLCanvasElement)
-  .setDensity(2)
+  .setDensity(window.devicePixelRatio >= 2 ? 2 : 1)
   .setStrokeCap('round')
   .setStrokeJoin('round');
 

--- a/docs/src/ts/examples/basic-shapes.ts
+++ b/docs/src/ts/examples/basic-shapes.ts
@@ -12,7 +12,7 @@ const rect = canvas.getBoundingClientRect();
 const randoms = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map(() => Math.random());
 
 canvas
-  .setDensity(2)
+  .setDensity(window.devicePixelRatio >= 2 ? 2 : 1)
   .setSize(rect.width, rect.height);
 
 const draw = () => {

--- a/docs/src/ts/examples/multiline-text.ts
+++ b/docs/src/ts/examples/multiline-text.ts
@@ -55,6 +55,7 @@ const draw = () => {
       FONT_SIZE * 2
     )
     .translate(multilineTextOffset, 0)
+    .beginPath()
     .strokeLine(0, 0, 0, height, '#AAAAAA')
     .setTextAlign('left')
     .fillTextMultiline(
@@ -65,6 +66,7 @@ const draw = () => {
       'normal'
     )
     .translate(MARGIN * 2 + multilineTextWidth, 0)
+    .beginPath()
     .strokeLine(0, 0, 0, height, '#AAAAAA')
     .setTextAlign('center')
     .fillTextMultiline(
@@ -75,6 +77,7 @@ const draw = () => {
       'break-word'
     )
     .translate(MARGIN * 2 + multilineTextWidth, 0)
+    .beginPath()
     .strokeLine(0, 0, 0, height, '#AAAAAA')
     .setTextAlign('right')
     .fillTextMultiline(

--- a/docs/src/ts/examples/multiline-text.ts
+++ b/docs/src/ts/examples/multiline-text.ts
@@ -12,7 +12,7 @@ const canvas = new Canvasimo(element as HTMLCanvasElement);
 const rect = canvas.getBoundingClientRect();
 
 canvas
-  .setDensity(2)
+  .setDensity(window.devicePixelRatio >= 2 ? 2 : 1)
   .setSize(rect.width, rect.height);
 
 const draw = () => {

--- a/docs/src/ts/examples/multiline-text.ts
+++ b/docs/src/ts/examples/multiline-text.ts
@@ -29,6 +29,18 @@ const draw = () => {
     .fillCanvas('#FFFFFF')
     .setTextBaseline('top')
     .setFontFamily('arial')
+    .setTextAlign('center')
+    .setFontSize(FONT_SIZE - 2)
+    .fillTextMultiline(
+      'Try resizing the window! :D',
+      width / 2,
+      FONT_SIZE * 4,
+      width - MARGIN * 2,
+      undefined,
+      undefined,
+      '#555555'
+    )
+    .setTextAlign('start')
     .setFontSize(FONT_SIZE)
     .fillText(
       'Regular text that does not have newlines or automatic wrapping',
@@ -42,19 +54,6 @@ const draw = () => {
       MARGIN,
       FONT_SIZE * 2
     )
-    .setTextAlign('center')
-    .setFontSize(FONT_SIZE - 2)
-    .fillTextMultiline(
-      'Try resizing the window! :D',
-      width / 2,
-      FONT_SIZE * 4,
-      width - MARGIN * 2,
-      undefined,
-      undefined,
-      '#555555'
-    )
-    .setFontSize(FONT_SIZE)
-    .setFill('black')
     .translate(multilineTextOffset, 0)
     .strokeLine(0, 0, 0, height, '#AAAAAA')
     .setTextAlign('left')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "canvasimo",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.7.2",
   "description": "An HTML5 canvas drawing library, with 150+ useful methods, jQuery-like fluent interface, and cross-browser compatibility enhancements.",
   "main": "dist/index.js",
+  "module": "build/index.js",
   "types": "build/index.d.ts",
   "directories": {
     "example": "examples"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "canvasimo",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "An HTML5 canvas drawing library, with 150+ useful methods, jQuery-like fluent interface, and cross-browser compatibility enhancements.",
   "main": "dist/index.js",
   "module": "build/index.js",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -53,12 +53,10 @@ export const MATCHES_ALL_WHITESPACE = /^\s*$/;
 export const MATCHES_FONT_SIZE = /(^|\s+)(\d*\.?\d+)([a-z]+|%)(\/\d*\.?\d+(?:[a-z]+|%)?)?\s/i;
 export const MATCHES_WORD_BREAKS = /(?![^\w\s])\b/g;
 
-export const DEFAULT_CONTEXT_VALUES = {
+export const DEFAULT_CONTEXT_VALUES: {[i: string]: string | number} = {
   globalAlpha: 1,
   globalCompositeOperation: 'source-over',
   filter: 'none',
-  imageSmoothingEnabled: true,
-  imageSmoothingQuality: 'low',
   strokeStyle: '#000000',
   fillStyle: '#000000',
   shadowOffsetX: 0,
@@ -74,3 +72,10 @@ export const DEFAULT_CONTEXT_VALUES = {
   textAlign: 'start',
   textBaseline: 'alphabetic',
 };
+
+export const DEFAULT_IMAGE_SMOOTHING_VALUES = {
+  imageSmoothingEnabled: true,
+  imageSmoothingQuality: 'low' as ImageSmoothingQuality,
+};
+
+export const DEFAULT_LINE_DASH = [];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -23,6 +23,13 @@ export const IMAGE_SMOOTHING_KEYS = [
   'webkitImageSmoothingEnabled',
 ] as Array<'imageSmoothingEnabled'>;
 
+export const IMAGE_SMOOTHING_QUALITY_KEYS = [
+  'imageSmoothingQuality',
+  'msImageSmoothingQuality',
+  'mozImageSmoothingQuality',
+  'webkitImageSmoothingQuality',
+] as Array<'imageSmoothingQuality'>;
+
 export const CONTEXT_TYPE = '2d';
 
 export const INCORRECT_POINT_FORMAT = `Path points must be an array of:\n

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,6 +39,7 @@ export const INCORRECT_GET_ANGLE_ARGUMENTS = 'Incorrect number of arguments supp
  'Arguments must be [x1, y1, x2, y2] or [x1, y1, x2, y2, x3, y3].';
 
 export const DEFAULT_FONT_PARTS = ['normal', 'normal', 'normal', '10px', 'sans-serif'];
+export const DEFAULT_FONT = DEFAULT_FONT_PARTS.join(' ');
 export const DEFAULT_DENSITY = 1;
 
 export const MATCHES_SPECIAL_FILL = /^(nonzero|evenodd)$/i;
@@ -51,3 +52,25 @@ export const MATCHES_WHITESPACE = /\s+/g;
 export const MATCHES_ALL_WHITESPACE = /^\s*$/;
 export const MATCHES_FONT_SIZE = /(^|\s+)(\d*\.?\d+)([a-z]+|%)(\/\d*\.?\d+(?:[a-z]+|%)?)?\s/i;
 export const MATCHES_WORD_BREAKS = /(?![^\w\s])\b/g;
+
+export const DEFAULT_CONTEXT_VALUES = {
+  globalAlpha: 1,
+  globalCompositeOperation: 'source-over',
+  filter: 'none',
+  imageSmoothingEnabled: true,
+  imageSmoothingQuality: 'low',
+  strokeStyle: '#000000',
+  fillStyle: '#000000',
+  shadowOffsetX: 0,
+  shadowOffsetY: 0,
+  shadowBlur: 0,
+  shadowColor: 'rgba(0, 0, 0, 0)',
+  lineWidth: 1,
+  lineCap: 'butt',
+  lineJoin: 'miter',
+  miterLimit: 10,
+  lineDashOffset: 0,
+  font: DEFAULT_FONT,
+  textAlign: 'start',
+  textBaseline: 'alphabetic',
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,7 +38,7 @@ export const INCORRECT_POINT_FORMAT = `Path points must be an array of:\n
 export const INCORRECT_GET_ANGLE_ARGUMENTS = 'Incorrect number of arguments supplied for getAngle. ' +
  'Arguments must be [x1, y1, x2, y2] or [x1, y1, x2, y2, x3, y3].';
 
-export const DEFAULT_FONT = ['normal', 'normal', 'normal', '10px', 'sans-serif'];
+export const DEFAULT_FONT_PARTS = ['normal', 'normal', 'normal', '10px', 'sans-serif'];
 export const DEFAULT_DENSITY = 1;
 
 export const MATCHES_SPECIAL_FILL = /^(nonzero|evenodd)$/i;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -56,7 +56,6 @@ export const MATCHES_WORD_BREAKS = /(?![^\w\s])\b/g;
 export const DEFAULT_CONTEXT_VALUES: {[i: string]: string | number} = {
   globalAlpha: 1,
   globalCompositeOperation: 'source-over',
-  filter: 'none',
   strokeStyle: '#000000',
   fillStyle: '#000000',
   shadowOffsetX: 0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,13 @@
 const { version: VERSION } = require('../package.json');
 import {
   CONTEXT_TYPE,
+  DEFAULT_CONTEXT_VALUES,
   DEFAULT_DENSITY,
   DEFAULT_FONT_PARTS,
+  DEFAULT_IMAGE_SMOOTHING_VALUES,
+  DEFAULT_LINE_DASH,
   IMAGE_SMOOTHING_KEYS,
+  IMAGE_SMOOTHING_QUALITY_KEYS,
   INCORRECT_GET_ANGLE_ARGUMENTS,
   MATCHES_ALL_WHITESPACE,
   MATCHES_WORD_BREAKS,
@@ -67,7 +71,7 @@ export class Canvasimo {
     }
 
     this.ctx = ctx;
-    this.ctx.font = formatFont(this.ctx.font, this.density, true);
+    this.setDefaultContextValues();
   }
 
   /**
@@ -2066,42 +2070,17 @@ export class Canvasimo {
       return this.drawTextWithLineBreaks(method, lines.join('\n'), x, y, lineHeight, color);
     }
   }
-  private resetDensityRelatedValues = (prevDensity: number, density: number, setSize: boolean): Canvasimo => {
-    this.density = prevDensity;
-
-    const {
-      width: prevWidth,
-      height: prevHeight,
-    } = this.getSize();
-
-    const prevFontSize = this.getFontSize();
-    const prevLineDash = this.getLineDash();
-    const prevLineDashOffset = this.getLineDashOffset();
-    const prevLineWidth = this.getLineWidth();
-    const prevMiterLimit = this.getMiterLimit();
-    const prevShadowBlur = this.getShadowBlur();
-    const prevShadowOffsetX = this.getShadowOffsetX();
-    const prevShadowOffsetY = this.getShadowOffsetY();
-
-    this.density = density;
-
-    if (prevDensity !== density) {
-      if (setSize) {
-        this.setSize(prevWidth, prevHeight);
+  private setDefaultContextValues = (): Canvasimo => {
+    for (const key in DEFAULT_CONTEXT_VALUES) {
+      if (key in this.ctx) {
+        this.setCanvasProperty(key, DEFAULT_CONTEXT_VALUES[key]);
       }
-
-      if (typeof prevFontSize === 'number') {
-        this.setFontSize(prevFontSize);
-      }
-
-      this.setLineDash(prevLineDash);
-      this.setLineDashOffset(prevLineDashOffset);
-      this.setLineWidth(prevLineWidth);
-      this.setMiterLimit(prevMiterLimit);
-      this.setShadowBlur(prevShadowBlur);
-      this.setShadowOffsetX(prevShadowOffsetX);
-      this.setShadowOffsetY(prevShadowOffsetY);
     }
+
+    this.setImageSmoothingEnabled(DEFAULT_IMAGE_SMOOTHING_VALUES.imageSmoothingEnabled);
+    this.setImageSmoothingQuality(DEFAULT_IMAGE_SMOOTHING_VALUES.imageSmoothingQuality);
+
+    this.setLineDash(DEFAULT_LINE_DASH);
 
     return this;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,9 +61,9 @@ const logUnsupportedMethodError = (method: string) => {
 export class Canvasimo {
   private element: HTMLCanvasElement;
   private ctx: CanvasRenderingContext2D;
+  private storedContextValues: StoredContextValues;
   private ctxType: typeof CONTEXT_TYPE = CONTEXT_TYPE;
   private density: number = DEFAULT_DENSITY;
-  private storedContextValues: StoredContextValues;
 
   public constructor (element: HTMLCanvasElement) {
     this.element = element;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
   ForEach,
   GetAngle,
   GlobalCompositeOperation,
+  LimitedTextMetrics,
   LineCap,
   LineJoin,
   MaxWidth,
@@ -915,16 +916,13 @@ export class Canvasimo {
    * Get information about the size text will be drawn.
    * @alias measureText
    */
-  public getTextSize = (text: string): TextMetrics => this.measureText(text);
-  public measureText = (text: string): TextMetrics => {
+  public getTextSize = (text: string): LimitedTextMetrics => this.measureText(text);
+  public measureText = (text: string): LimitedTextMetrics => {
     const metrics = this.ctx.measureText(text);
-    const metricsWithDensity: any = {};
 
-    (Object.keys(metrics) as ReadonlyArray<keyof TextMetrics>).forEach((key) => {
-      metricsWithDensity[key] = (metrics[key] || 0) / this.density;
-    });
-
-    return metricsWithDensity;
+    return {
+      width: (metrics.width || 0) / this.density,
+    };
   }
   /**
    * Set the horizontal text alignment.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1754,7 +1754,7 @@ export class Canvasimo {
       }
     }
 
-    return DEFAULT_CONTEXT_VALUES.imageSmoothingQuality as ImageSmoothingQuality;
+    return DEFAULT_IMAGE_SMOOTHING_VALUES.imageSmoothingQuality;
   }
   /**
    * Set how blurry shadows are.

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import {
   CanvasContext,
   CanvasContextAttributes,
   CreateImageData,
+  DensityRelatedValues,
   DrawImage,
   Fill,
   FillOrStrokeStyle,
@@ -61,6 +62,7 @@ export class Canvasimo {
   private ctx: CanvasRenderingContext2D;
   private ctxType: typeof CONTEXT_TYPE = CONTEXT_TYPE;
   private density: number = DEFAULT_DENSITY;
+  private previousDensityRelatedValues: DensityRelatedValues;
 
   public constructor (element: HTMLCanvasElement) {
     this.element = element;
@@ -72,6 +74,7 @@ export class Canvasimo {
 
     this.ctx = ctx;
     this.setDefaultContextValues();
+    this.previousDensityRelatedValues = this.saveDensityRelatedValues();
   }
 
   /**
@@ -2083,6 +2086,42 @@ export class Canvasimo {
     this.setLineDash(DEFAULT_LINE_DASH);
 
     return this;
+  }
+  private saveDensityRelatedValues = (): DensityRelatedValues => {
+    this.previousDensityRelatedValues = {
+      font: this.getFont(),
+      lineDashOffset: this.getLineDashOffset(),
+      lineDash: this.getLineDash(),
+      lineWidth: this.getLineWidth(),
+      miterLimit: this.getMiterLimit(),
+      shadowBlur: this.getShadowBlur(),
+      shadowOffsetX: this.getShadowOffsetX(),
+      shadowOffsetY: this.getShadowOffsetY(),
+    };
+
+    return this.previousDensityRelatedValues;
+  }
+  private restoreDensityRelatedValues = (): Canvasimo => {
+    const {
+      font,
+      lineDashOffset,
+      lineDash,
+      lineWidth,
+      miterLimit,
+      shadowBlur,
+      shadowOffsetX,
+      shadowOffsetY,
+    } = this.previousDensityRelatedValues;
+
+    return this
+      .setFont(font)
+      .setLineDashOffset(lineDashOffset)
+      .setLineDash(lineDash)
+      .setLineWidth(lineWidth)
+      .setMiterLimit(miterLimit)
+      .setShadowBlur(shadowBlur)
+      .setShadowOffsetX(shadowOffsetX)
+      .setShadowOffsetY(shadowOffsetY);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1720,7 +1720,7 @@ export class Canvasimo {
    */
   public getImageSmoothingEnabled = (): boolean => {
     for (const key of IMAGE_SMOOTHING_KEYS) {
-      if (Object.prototype.hasOwnProperty.call(this.ctx, key)) {
+      if (key in this.ctx) {
         return this.ctx[key];
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1728,6 +1728,31 @@ export class Canvasimo {
     return false;
   }
   /**
+   * Set the image smoothing quality.
+   */
+  public setImageSmoothingQuality = (value: ImageSmoothingQuality): Canvasimo => {
+    for (const key of IMAGE_SMOOTHING_QUALITY_KEYS) {
+      if (key in this.ctx) {
+        this.ctx[key] = value;
+        return this;
+      }
+    }
+
+    return this;
+  }
+  /**
+   * Get the current image smoothing quality.
+   */
+  public getImageSmoothingQuality = (): ImageSmoothingQuality => {
+    for (const key of IMAGE_SMOOTHING_QUALITY_KEYS) {
+      if (key in this.ctx) {
+        return this.ctx[key];
+      }
+    }
+
+    return DEFAULT_CONTEXT_VALUES.imageSmoothingQuality as ImageSmoothingQuality;
+  }
+  /**
    * Set how blurry shadows are.
    */
   public setShadowBlur = (value: number): Canvasimo => this.setCanvasProperty('shadowBlur', value * this.density);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1707,7 +1707,7 @@ export class Canvasimo {
    */
   public setImageSmoothingEnabled = (value: BooleanFalsy): Canvasimo => {
     for (const key of IMAGE_SMOOTHING_KEYS) {
-      if (Object.prototype.hasOwnProperty.call(this.ctx, key)) {
+      if (key in this.ctx) {
         this.ctx[key] = value || false;
         return this;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ const { version: VERSION } = require('../package.json');
 import {
   CONTEXT_TYPE,
   DEFAULT_DENSITY,
-  DEFAULT_FONT,
+  DEFAULT_FONT_PARTS,
   IMAGE_SMOOTHING_KEYS,
   INCORRECT_GET_ANGLE_ARGUMENTS,
   MATCHES_ALL_WHITESPACE,
@@ -942,7 +942,7 @@ export class Canvasimo {
     if (parts.length < 5) {
       return this.setFont('');
     }
-    parts[4] = family || DEFAULT_FONT[4];
+    parts[4] = family || DEFAULT_FONT_PARTS[4];
     this.ctx.font = formatFont(parts.join(' '), this.density, false);
     return this;
   }
@@ -964,7 +964,7 @@ export class Canvasimo {
     if (parts.length < 5) {
       return this.setFont('');
     }
-    parts[3] = (typeof size === 'number' ? size + 'px' : size) || DEFAULT_FONT[3];
+    parts[3] = (typeof size === 'number' ? size + 'px' : size) || DEFAULT_FONT_PARTS[3];
     this.ctx.font = formatFont(parts.join(' '), this.density, false);
     return this;
   }
@@ -987,7 +987,7 @@ export class Canvasimo {
     if (parts.length < 5) {
       return this.setFont('');
     }
-    parts[0] = style || DEFAULT_FONT[0];
+    parts[0] = style || DEFAULT_FONT_PARTS[0];
     this.ctx.font = formatFont(parts.join(' '), this.density, false);
     return this;
   }
@@ -1010,7 +1010,7 @@ export class Canvasimo {
     if (parts.length < 5) {
       return this.setFont('');
     }
-    parts[1] = variant || DEFAULT_FONT[1];
+    parts[1] = variant || DEFAULT_FONT_PARTS[1];
     this.ctx.font = formatFont(parts.join(' '), this.density, false);
     return this;
   }
@@ -1033,7 +1033,7 @@ export class Canvasimo {
     if (parts.length < 5) {
       return this.setFont('');
     }
-    parts[2] = weight.toString() || DEFAULT_FONT[2];
+    parts[2] = weight.toString() || DEFAULT_FONT_PARTS[2];
     this.ctx.font = formatFont(parts.join(' '), this.density, false);
     return this;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,14 +108,24 @@ export interface ForEach {
   (obj: {[i: string]: any}, callback: (value: any, key: string) => any): Canvasimo;
 }
 
-export interface DensityRelatedValues {
-  font: string;
-  lineDashOffset: number;
-  lineWidth: number;
-  miterLimit: number;
-  shadowBlur: number;
+export interface StoredContextValues {
+  globalAlpha: number;
+  globalCompositeOperation: GlobalCompositeOperation;
+  strokeStyle: FillOrStrokeStyle;
+  fillStyle: FillOrStrokeStyle;
   shadowOffsetX: number;
   shadowOffsetY: number;
-  // Has setter and getter
+  shadowBlur: number;
+  shadowColor: string;
+  lineWidth: number;
+  lineCap: LineCap;
+  lineJoin: LineJoin;
+  miterLimit: number;
+  lineDashOffset: number;
+  font: string;
+  textAlign: TextAlign;
+  textBaseline: TextBaseline;
+  imageSmoothingEnabled: boolean;
+  imageSmoothingQuality: ImageSmoothingQuality;
   lineDash: number[];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,3 +107,14 @@ export interface ForEach {
   (obj: any[], callback: (value: any, index: number) => any): Canvasimo;
   (obj: {[i: string]: any}, callback: (value: any, key: string) => any): Canvasimo;
 }
+
+export interface DensityRelatedValues {
+  font: string;
+  getLineDash: number[];
+  lineDashOffset: number;
+  lineWidth: number;
+  miterLimit: number;
+  shadowBlur: number;
+  shadowOffsetX: number;
+  shadowOffsetY: number;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,3 +129,7 @@ export interface StoredContextValues {
   imageSmoothingQuality: ImageSmoothingQuality;
   lineDash: number[];
 }
+
+export interface LimitedTextMetrics {
+  width: number;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,11 @@ export type Size = {
   height: number;
 };
 
+// tslint:disable-next-line:interface-over-type-literal
+export type LimitedTextMetrics = {
+  width: number;
+};
+
 export interface SetSize {
   (size: Size): Canvasimo;
   (width: number, height: number): Canvasimo;
@@ -128,8 +133,4 @@ export interface StoredContextValues {
   imageSmoothingEnabled: boolean;
   imageSmoothingQuality: ImageSmoothingQuality;
   lineDash: number[];
-}
-
-export interface LimitedTextMetrics {
-  width: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,11 +110,12 @@ export interface ForEach {
 
 export interface DensityRelatedValues {
   font: string;
-  getLineDash: number[];
   lineDashOffset: number;
   lineWidth: number;
   miterLimit: number;
   shadowBlur: number;
   shadowOffsetX: number;
   shadowOffsetY: number;
+  // Has setter and getter
+  lineDash: number[];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import {
-  DEFAULT_FONT,
+  DEFAULT_FONT_PARTS,
   INCORRECT_POINT_FORMAT,
   MATCHES_FONT_SIZE,
   MATCHES_FONT_STYLE,
@@ -30,7 +30,7 @@ let warnedAboutLineHeight = false;
 
 export const getFontParts = (input: string | undefined, density: number, getter: boolean) => {
   if (!input) {
-    return DEFAULT_FONT;
+    return DEFAULT_FONT_PARTS;
   }
 
   const font = input.trim();
@@ -42,7 +42,7 @@ export const getFontParts = (input: string | undefined, density: number, getter:
   const matchFontSize = MATCHES_FONT_SIZE.exec(font);
 
   if (!matchFontSize) {
-    return DEFAULT_FONT;
+    return DEFAULT_FONT_PARTS;
   }
 
   const fontString = matchFontSize[0].trim();
@@ -83,15 +83,15 @@ export const getFontParts = (input: string | undefined, density: number, getter:
       } else if (MATCHES_NORMAL.test(optionalParts[0])) {
         optionalParts.splice(0, 1);
       } else {
-        return DEFAULT_FONT;
+        return DEFAULT_FONT_PARTS;
       }
     }
   }
 
   return [
-    fontStyle || DEFAULT_FONT[0],
-    fontVariant || DEFAULT_FONT[1],
-    fontWeight || DEFAULT_FONT[2],
+    fontStyle || DEFAULT_FONT_PARTS[0],
+    fontVariant || DEFAULT_FONT_PARTS[1],
+    fontWeight || DEFAULT_FONT_PARTS[2],
     fontSize,
     fontFamily,
   ];

--- a/tests/__snapshots__/docs.ts.snap
+++ b/tests/__snapshots__/docs.ts.snap
@@ -2017,7 +2017,14 @@ The lineHeight parameter is a multiplier for the font size, and defaults to 1.",
             "returns": "LimitedTextMetrics",
           },
         ],
-        "typeAliases": Array [],
+        "typeAliases": Array [
+          Object {
+            "alias": "{
+  width: number;
+}",
+            "name": "LimitedTextMetrics",
+          },
+        ],
       },
       Object {
         "alias": null,

--- a/tests/__snapshots__/docs.ts.snap
+++ b/tests/__snapshots__/docs.ts.snap
@@ -2014,7 +2014,7 @@ The lineHeight parameter is a multiplier for the font size, and defaults to 1.",
                 "type": "string",
               },
             ],
-            "returns": "TextMetrics",
+            "returns": "LimitedTextMetrics",
           },
         ],
         "typeAliases": Array [],
@@ -4096,6 +4096,46 @@ a canvas with a height of 100 returns 20 if the provided value is 20.",
           },
         ],
         "typeAliases": Array [],
+      },
+      Object {
+        "alias": null,
+        "description": "Set the image smoothing quality.",
+        "name": "setImageSmoothingQuality",
+        "signatures": Array [
+          Object {
+            "parameters": Array [
+              Object {
+                "name": "value",
+                "optional": false,
+                "type": "ImageSmoothingQuality",
+              },
+            ],
+            "returns": "Canvasimo",
+          },
+        ],
+        "typeAliases": Array [
+          Object {
+            "alias": "\\"low\\" | \\"medium\\" | \\"high\\"",
+            "name": "ImageSmoothingQuality",
+          },
+        ],
+      },
+      Object {
+        "alias": null,
+        "description": "Get the current image smoothing quality.",
+        "name": "getImageSmoothingQuality",
+        "signatures": Array [
+          Object {
+            "parameters": Array [],
+            "returns": "ImageSmoothingQuality",
+          },
+        ],
+        "typeAliases": Array [
+          Object {
+            "alias": "\\"low\\" | \\"medium\\" | \\"high\\"",
+            "name": "ImageSmoothingQuality",
+          },
+        ],
       },
       Object {
         "alias": null,

--- a/tests/density.ts
+++ b/tests/density.ts
@@ -25,8 +25,6 @@ describe('density', () => {
   });
 
   it('retains density when the canvas is cleared (without changing the canvas size)', () => {
-    // Fake browser font reset
-    ctx.font = '10px sans-serif';
     instance.clearCanvas();
 
     expect(ctx.font).toBe('normal normal normal 20px sans-serif');

--- a/tests/docs.ts
+++ b/tests/docs.ts
@@ -9,6 +9,7 @@ const PRIVATE_PROPERTIES = [
   'ctx',
   'ctxType',
   'density',
+  'storedContextValues',
   'setCanvasProperty',
   'getCanvasProperty',
   'drawTextWithLineBreaks',
@@ -17,6 +18,9 @@ const PRIVATE_PROPERTIES = [
   'wrapNormal',
   'textMultiline',
   'resetDensityRelatedValues',
+  'setDefaultContextValues',
+  'saveContextValues',
+  'restoreContextValues',
 ];
 
 describe('getDocJson', () => {

--- a/tests/docs.ts
+++ b/tests/docs.ts
@@ -7,9 +7,9 @@ import getContextStub from './helpers/get-context-stub';
 const PRIVATE_PROPERTIES = [
   'element',
   'ctx',
+  'storedContextValues',
   'ctxType',
   'density',
-  'storedContextValues',
   'setCanvasProperty',
   'getCanvasProperty',
   'drawTextWithLineBreaks',
@@ -17,7 +17,6 @@ const PRIVATE_PROPERTIES = [
   'wrapBreakWord',
   'wrapNormal',
   'textMultiline',
-  'resetDensityRelatedValues',
   'setDefaultContextValues',
   'saveContextValues',
   'restoreContextValues',

--- a/tests/helpers/constants.ts
+++ b/tests/helpers/constants.ts
@@ -1,3 +1,3 @@
-export const NUMBER_OF_PROPERTIES = 200;
+export const NUMBER_OF_PROPERTIES = 199;
 export const NUMBER_OF_DOC_GROUPS = 16;
 export const CLASS_NAME = 'Canvasimo';

--- a/tests/helpers/constants.ts
+++ b/tests/helpers/constants.ts
@@ -1,3 +1,3 @@
-export const NUMBER_OF_PROPERTIES = 194;
+export const NUMBER_OF_PROPERTIES = 200;
 export const NUMBER_OF_DOC_GROUPS = 16;
 export const CLASS_NAME = 'Canvasimo';

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -82,7 +82,8 @@ describe('canvasimo', () => {
     textMultiline: [jest.fn(), '', 0, 0],
   };
 
-  const isGetter = /^(get|create|is|measure|constrain|map|version|wrapBreakAll|wrapBreakWord|wrapNormal)/i;
+  // tslint:disable-next-line:max-line-length
+  const isGetter = /^(get|create|is|measure|constrain|map|version|wrapBreakAll|wrapBreakWord|wrapNormal|saveContextValues)/i;
 
   beforeEach(() => {
     mockClearAll();
@@ -569,9 +570,9 @@ describe('canvasimo', () => {
 
   describe('actions and setters', () => {
 
-    it('should return the canvas', () => {
+    it('should return the canvasimo instance', () => {
       each(canvas, (method, key) => {
-        if (typeof method === 'function' && !isGetter.exec(key)) {
+        if (typeof method === 'function' && !isGetter.test(key)) {
           let result;
 
           try {


### PR DESCRIPTION
* Fix `measureText` / `getTextSize` following TypeScript upgrade (in v0.7.0) backported to 0.7.3
* Add `setImageSmoothingQuality` and `getImageSmoothingQuality`
* Set initial canvas values upon construction (for cross-browser consistency)
* Restore canvas context values when resizing the element (including clearing the canvas)
* Update docs examples
* Improve density in examples
* Fix redrawing bug in IE multi-line text example (by calling `beginPath` before drawing lines)
* Add `module` entry to package.json